### PR TITLE
fix(tekton): pipeline run trigger properties

### DIFF
--- a/examples/test_cd_tekton_pipeline_v2_examples.py
+++ b/examples/test_cd_tekton_pipeline_v2_examples.py
@@ -189,15 +189,10 @@ class TestCdTektonPipelineV2Examples:
             print('\ncreate_tekton_pipeline_run() result:')
             # begin-create_tekton_pipeline_run
 
-            property_model = {
-                'name': 'testString',
-                'type': 'secure',
-            }
-
             pipeline_run_trigger_model = {
                 'name': 'Manual Trigger 1',
-                'properties': [property_model],
-                'secure_properties': [property_model],
+                'properties': {'pipeline-debug':'false'},
+                'secure_properties': {'secure-property-key':'secure value'},
                 'headers': {'source':'api'},
                 'body': {'message':'hello world','enable':'true','detail':{'name':'example'}},
             }

--- a/ibm_continuous_delivery/cd_tekton_pipeline_v2.py
+++ b/ibm_continuous_delivery/cd_tekton_pipeline_v2.py
@@ -409,8 +409,8 @@ class CdTektonPipelineV2(BaseService):
         pipeline_id: str,
         *,
         trigger_name: str = None,
-        trigger_properties: List['Property'] = None,
-        secure_trigger_properties: List['Property'] = None,
+        trigger_properties: dict = None,
+        secure_trigger_properties: dict = None,
         trigger_headers: dict = None,
         trigger_body: dict = None,
         trigger: 'PipelineRunTrigger' = None,
@@ -424,12 +424,12 @@ class CdTektonPipelineV2(BaseService):
 
         :param str pipeline_id: The Tekton pipeline ID.
         :param str trigger_name: (optional) Trigger name.
-        :param List[Property] trigger_properties: (optional) An object containing
-               string values only that provides additional `text` properties, or overrides
+        :param dict trigger_properties: (optional) An object containing string
+               values only that provides additional `text` properties, or overrides
                existing pipeline/trigger properties, to use for the created run.
-        :param List[Property] secure_trigger_properties: (optional) An object
-               containing string values only that provides additional `secure` properties,
-               or overrides existing `secure` pipeline/trigger properties, to use for the
+        :param dict secure_trigger_properties: (optional) An object containing
+               string values only that provides additional `secure` properties, or
+               overrides existing `secure` pipeline/trigger properties, to use for the
                created run.
         :param dict trigger_headers: (optional) An object containing string values
                only that provides the request headers. Use `$(header.header_key_name)` to
@@ -449,10 +449,6 @@ class CdTektonPipelineV2(BaseService):
 
         if not pipeline_id:
             raise ValueError('pipeline_id must be provided')
-        if trigger_properties is not None:
-            trigger_properties = [convert_model(x) for x in trigger_properties]
-        if secure_trigger_properties is not None:
-            secure_trigger_properties = [convert_model(x) for x in secure_trigger_properties]
         if trigger is not None:
             trigger = convert_model(trigger)
         headers = {}
@@ -3100,12 +3096,12 @@ class PipelineRunTrigger:
     Trigger details passed when triggering a Tekton pipeline run.
 
     :attr str name: Trigger name.
-    :attr List[Property] properties: (optional) An object containing string values
-          only that provides additional `text` properties, or overrides existing
+    :attr dict properties: (optional) An object containing string values only that
+          provides additional `text` properties, or overrides existing pipeline/trigger
+          properties, to use for the created run.
+    :attr dict secure_properties: (optional) An object containing string values only
+          that provides additional `secure` properties, or overrides existing `secure`
           pipeline/trigger properties, to use for the created run.
-    :attr List[Property] secure_properties: (optional) An object containing string
-          values only that provides additional `secure` properties, or overrides existing
-          `secure` pipeline/trigger properties, to use for the created run.
     :attr dict headers_: (optional) An object containing string values only that
           provides the request headers. Use `$(header.header_key_name)` to access it in a
           TriggerBinding. Most commonly used as part of a Generic Webhook to provide a
@@ -3120,8 +3116,8 @@ class PipelineRunTrigger:
         self,
         name: str,
         *,
-        properties: List['Property'] = None,
-        secure_properties: List['Property'] = None,
+        properties: dict = None,
+        secure_properties: dict = None,
         headers_: dict = None,
         body: dict = None,
     ) -> None:
@@ -3129,13 +3125,12 @@ class PipelineRunTrigger:
         Initialize a PipelineRunTrigger object.
 
         :param str name: Trigger name.
-        :param List[Property] properties: (optional) An object containing string
-               values only that provides additional `text` properties, or overrides
-               existing pipeline/trigger properties, to use for the created run.
-        :param List[Property] secure_properties: (optional) An object containing
-               string values only that provides additional `secure` properties, or
-               overrides existing `secure` pipeline/trigger properties, to use for the
-               created run.
+        :param dict properties: (optional) An object containing string values only
+               that provides additional `text` properties, or overrides existing
+               pipeline/trigger properties, to use for the created run.
+        :param dict secure_properties: (optional) An object containing string
+               values only that provides additional `secure` properties, or overrides
+               existing `secure` pipeline/trigger properties, to use for the created run.
         :param dict headers_: (optional) An object containing string values only
                that provides the request headers. Use `$(header.header_key_name)` to
                access it in a TriggerBinding. Most commonly used as part of a Generic
@@ -3161,9 +3156,9 @@ class PipelineRunTrigger:
         else:
             raise ValueError('Required property \'name\' not present in PipelineRunTrigger JSON')
         if 'properties' in _dict:
-            args['properties'] = [Property.from_dict(v) for v in _dict.get('properties')]
+            args['properties'] = _dict.get('properties')
         if 'secure_properties' in _dict:
-            args['secure_properties'] = [Property.from_dict(v) for v in _dict.get('secure_properties')]
+            args['secure_properties'] = _dict.get('secure_properties')
         if 'headers' in _dict:
             args['headers_'] = _dict.get('headers')
         if 'body' in _dict:
@@ -3181,21 +3176,9 @@ class PipelineRunTrigger:
         if hasattr(self, 'name') and self.name is not None:
             _dict['name'] = self.name
         if hasattr(self, 'properties') and self.properties is not None:
-            properties_list = []
-            for v in self.properties:
-                if isinstance(v, dict):
-                    properties_list.append(v)
-                else:
-                    properties_list.append(v.to_dict())
-            _dict['properties'] = properties_list
+            _dict['properties'] = self.properties
         if hasattr(self, 'secure_properties') and self.secure_properties is not None:
-            secure_properties_list = []
-            for v in self.secure_properties:
-                if isinstance(v, dict):
-                    secure_properties_list.append(v)
-                else:
-                    secure_properties_list.append(v.to_dict())
-            _dict['secure_properties'] = secure_properties_list
+            _dict['secure_properties'] = self.secure_properties
         if hasattr(self, 'headers_') and self.headers_ is not None:
             _dict['headers'] = self.headers_
         if hasattr(self, 'body') and self.body is not None:

--- a/test/integration/test_cd_tekton_pipeline_v2.py
+++ b/test/integration/test_cd_tekton_pipeline_v2.py
@@ -69,6 +69,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_create_toolchain(self):
+        print('\n Create toolchain.', flush=True)
         global toolchain_id_link
         response = self.cd_toolchain_service.create_toolchain(
             name='PythonPipelineSDKTest',
@@ -82,6 +83,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_create_github_tool(self):
+        print('\n Create github tool.', flush=True)
         global github_tool_id_link
         response = self.cd_toolchain_service.create_tool(
             toolchain_id=toolchain_id_link,
@@ -101,6 +103,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_create_pipeline_tool(self):
+        print('\n Create pipeline tool.', flush=True)
         global pipeline_tool_id_link
         response = self.cd_toolchain_service.create_tool(
             toolchain_id=toolchain_id_link,
@@ -117,6 +120,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_create_tekton_pipeline(self):
+        print('\n Create Tekton Pipeline.', flush=True)
         # Construct a dict representation of a WorkerIdentity model
         worker_identity_model = {
             'id': 'public',
@@ -133,6 +137,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_get_tekton_pipeline(self):
+        print('\n Get Tekton Pipeline.', flush=True)
         response = self.cd_pipeline_service.get_tekton_pipeline(
             id=pipeline_tool_id_link
         )
@@ -142,6 +147,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_update_tekton_pipeline(self):
+        print('\n Update Tekton Pipeline.', flush=True)
         # Construct a dict representation of a TektonPipelinePatch model
         tekton_pipeline_patch_model = {
             'enable_notifications': True,
@@ -157,6 +163,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_create_tekton_pipeline_definition(self):
+        print('\n Create definition.', flush=True)
         global definition_id_link
         # Construct a dict representation of a DefinitionSourceProperties model
         definition_source_properties_model = {
@@ -190,6 +197,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_get_tekton_pipeline_definition(self):
+        print('\n Get definition.', flush=True)
         response = self.cd_pipeline_service.get_tekton_pipeline_definition(
             pipeline_id=pipeline_tool_id_link,
             definition_id=definition_id_link
@@ -200,6 +208,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_list_tekton_pipeline_definitions(self):
+        print('\n List definitions.', flush=True)
         response = self.cd_pipeline_service.list_tekton_pipeline_definitions(
             pipeline_id=pipeline_tool_id_link
         )
@@ -219,6 +228,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_create_tekton_pipeline_properties(self):
+        print('\n Create property.', flush=True)
         response = self.cd_pipeline_service.create_tekton_pipeline_properties(
             pipeline_id=pipeline_tool_id_link,
             name='prop1',
@@ -234,6 +244,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_get_tekton_pipeline_property(self):
+        print('\n Get property definition.', flush=True)
         response = self.cd_pipeline_service.get_tekton_pipeline_property(
             pipeline_id=pipeline_tool_id_link,
             property_name='prop1'
@@ -244,6 +255,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_replace_tekton_pipeline_property(self):
+        print('\n Update property.', flush=True)
         response = self.cd_pipeline_service.replace_tekton_pipeline_property(
             pipeline_id=pipeline_tool_id_link,
             property_name='prop1',
@@ -260,6 +272,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_list_tekton_pipeline_properties(self):
+        print('\n List properties.', flush=True)
         response = self.cd_pipeline_service.list_tekton_pipeline_properties(
             pipeline_id=pipeline_tool_id_link,
             sort='name'
@@ -276,6 +289,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_create_tekton_pipeline_trigger(self):
+        print('\n Create trigger.', flush=True)
         global trigger_id_link
         response = self.cd_pipeline_service.create_tekton_pipeline_trigger(
             pipeline_id=pipeline_tool_id_link,
@@ -298,6 +312,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_get_tekton_pipeline_trigger(self):
+        print('\n Get trigger.', flush=True)
         response = self.cd_pipeline_service.get_tekton_pipeline_trigger(
             pipeline_id=pipeline_tool_id_link,
             trigger_id=trigger_id_link
@@ -315,6 +330,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_update_tekton_pipeline_trigger(self):
+        print('\n Update trigger.', flush=True)
         # Construct a dict representation of a TriggerPatch model
         trigger_patch_model = {
             'type': 'manual',
@@ -341,6 +357,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_duplicate_tekton_pipeline_trigger(self):
+        print('\n Duplicate trigger.', flush=True)
         response = self.cd_pipeline_service.duplicate_tekton_pipeline_trigger(
             pipeline_id=pipeline_tool_id_link,
             source_trigger_id=trigger_id_link,
@@ -359,6 +376,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_list_tekton_pipeline_triggers(self):
+        print('\n List triggers.', flush=True)
         response = self.cd_pipeline_service.list_tekton_pipeline_triggers(
             pipeline_id=pipeline_tool_id_link,
             type='manual'
@@ -379,6 +397,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_create_tekton_pipeline_trigger_properties(self):
+        print('\n Create trigger property.', flush=True)
         global trigger_prop_name_link
         response = self.cd_pipeline_service.create_tekton_pipeline_trigger_properties(
             pipeline_id=pipeline_tool_id_link,
@@ -397,6 +416,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_get_tekton_pipeline_trigger_property(self):
+        print('\n Get trigger property.', flush=True)
         response = self.cd_pipeline_service.get_tekton_pipeline_trigger_property(
             pipeline_id=pipeline_tool_id_link,
             trigger_id=trigger_id_link,
@@ -411,6 +431,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_replace_tekton_pipeline_trigger_property(self):
+        print('\n Update trigger property.', flush=True)
         response = self.cd_pipeline_service.replace_tekton_pipeline_trigger_property(
             pipeline_id=pipeline_tool_id_link,
             trigger_id=trigger_id_link,
@@ -428,6 +449,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_list_tekton_pipeline_trigger_properties(self):
+        print('\n List trigger properties.', flush=True)
         response = self.cd_pipeline_service.list_tekton_pipeline_trigger_properties(
             pipeline_id=pipeline_tool_id_link,
             trigger_id=trigger_id_link,
@@ -444,20 +466,13 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_create_tekton_pipeline_run(self):
+        print('\n Create PipelineRun.', flush=True)
         global pipeline_run_id_link
-        # Construct a dict representation of a Property model
-        property_model = {
-            'addedProp1': 'addedProp123'
-        }
-        # Construct a dict representation of a Secure Property model
-        secure_property_model = {
-            'addedSecProp1': 'addedSecProp123'
-        }
         # Construct a dict representation of a Trigger model
         trigger_model = {
             'name': 'start-deploy',
-            'properties': property_model,
-            'secure_properties': secure_property_model,
+            'properties': {'addedProp1': 'addedProp123'},
+            'secure_properties': {'addedSecProp1': 'addedSecProp123'},
             'headers': {'source':'api'},
             'body': {'message':'hello world','enable':'true','detail':{'name':'example'}},
         }
@@ -485,6 +500,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_get_tekton_pipeline_run(self):
+        print('\n Get PipelineRun.', flush=True)
         response = self.cd_pipeline_service.get_tekton_pipeline_run(
             pipeline_id=pipeline_tool_id_link,
             id=pipeline_run_id_link
@@ -508,6 +524,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_rerun_tekton_pipeline_run(self):
+        print('\n Rerun PipelineRun.', flush=True)
         global rerun_id_link
         response = self.cd_pipeline_service.rerun_tekton_pipeline_run(
             pipeline_id=pipeline_tool_id_link,
@@ -533,6 +550,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_list_tekton_pipeline_runs(self):
+        print('\n List PipelineRuns.', flush=True)
         response = self.cd_pipeline_service.list_tekton_pipeline_runs(
             pipeline_id=pipeline_tool_id_link,
             limit=5
@@ -593,9 +611,9 @@ class TestCdTektonPipelineV2():
     #     step_log = response.get_result()
     #     assert step_log is not None
 
-
     @needscredentials
     def test_delete_tekton_pipeline_run(self):
+        print('\n Delete PipelineRun.', flush=True)
         response = self.cd_pipeline_service.delete_tekton_pipeline_run(
             pipeline_id=pipeline_tool_id_link,
             id=pipeline_run_id_link
@@ -605,6 +623,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_delete_tekton_pipeline_definition(self):
+        print('\n Delete definition.', flush=True)
         response = self.cd_pipeline_service.delete_tekton_pipeline_definition(
             pipeline_id=pipeline_tool_id_link,
             definition_id=definition_id_link
@@ -614,6 +633,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_delete_tekton_pipeline_property(self):
+        print('\n Delete property.', flush=True)
         response = self.cd_pipeline_service.delete_tekton_pipeline_property(
             pipeline_id=pipeline_tool_id_link,
             property_name='prop1'
@@ -623,6 +643,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_delete_tekton_pipeline_trigger_property(self):
+        print('\n Delete trigger property.', flush=True)
         response = self.cd_pipeline_service.delete_tekton_pipeline_trigger_property(
             pipeline_id=pipeline_tool_id_link,
             trigger_id=trigger_id_link,
@@ -633,6 +654,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_delete_tekton_pipeline_trigger(self):
+        print('\n Delete trigger.', flush=True)
         response = self.cd_pipeline_service.delete_tekton_pipeline_trigger(
             pipeline_id=pipeline_tool_id_link,
             trigger_id=trigger_id_link
@@ -642,6 +664,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_delete_tekton_pipeline(self):
+        print('\n Delete tekton pipeline.', flush=True)
         response = self.cd_pipeline_service.delete_tekton_pipeline(
             id=pipeline_tool_id_link
         )
@@ -650,6 +673,7 @@ class TestCdTektonPipelineV2():
 
     @needscredentials
     def test_delete_toolchain(self):
+        print('\n Delete toolchain.', flush=True)
         response = self.cd_toolchain_service.delete_toolchain(
             toolchain_id=toolchain_id_link
         )

--- a/test/unit/test_cd_tekton_pipeline_v2.py
+++ b/test/unit/test_cd_tekton_pipeline_v2.py
@@ -783,28 +783,19 @@ class TestCreateTektonPipelineRun:
             status=201,
         )
 
-        # Construct a dict representation of a Property model
-        property_model = {}
-        property_model['name'] = 'testString'
-        property_model['value'] = 'testString'
-        property_model['href'] = 'testString'
-        property_model['enum'] = ['testString']
-        property_model['type'] = 'secure'
-        property_model['path'] = 'testString'
-
         # Construct a dict representation of a PipelineRunTrigger model
         pipeline_run_trigger_model = {}
         pipeline_run_trigger_model['name'] = 'Manual Trigger 1'
-        pipeline_run_trigger_model['properties'] = [property_model]
-        pipeline_run_trigger_model['secure_properties'] = [property_model]
+        pipeline_run_trigger_model['properties'] = {'anyKey': 'anyValue'}
+        pipeline_run_trigger_model['secure_properties'] = {'anyKey': 'anyValue'}
         pipeline_run_trigger_model['headers'] = {'anyKey': 'anyValue'}
         pipeline_run_trigger_model['body'] = {'anyKey': 'anyValue'}
 
         # Set up parameter values
         pipeline_id = '94619026-912b-4d92-8f51-6c74f0692d90'
         trigger_name = 'testString'
-        trigger_properties = [property_model]
-        secure_trigger_properties = [property_model]
+        trigger_properties = {'anyKey': 'anyValue'}
+        secure_trigger_properties = {'anyKey': 'anyValue'}
         trigger_headers = {'anyKey': 'anyValue'}
         trigger_body = {'anyKey': 'anyValue'}
         trigger = pipeline_run_trigger_model
@@ -827,8 +818,8 @@ class TestCreateTektonPipelineRun:
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body['trigger_name'] == 'testString'
-        assert req_body['trigger_properties'] == [property_model]
-        assert req_body['secure_trigger_properties'] == [property_model]
+        assert req_body['trigger_properties'] == {'anyKey': 'anyValue'}
+        assert req_body['secure_trigger_properties'] == {'anyKey': 'anyValue'}
         assert req_body['trigger_headers'] == {'anyKey': 'anyValue'}
         assert req_body['trigger_body'] == {'anyKey': 'anyValue'}
         assert req_body['trigger'] == pipeline_run_trigger_model
@@ -858,28 +849,19 @@ class TestCreateTektonPipelineRun:
             status=201,
         )
 
-        # Construct a dict representation of a Property model
-        property_model = {}
-        property_model['name'] = 'testString'
-        property_model['value'] = 'testString'
-        property_model['href'] = 'testString'
-        property_model['enum'] = ['testString']
-        property_model['type'] = 'secure'
-        property_model['path'] = 'testString'
-
         # Construct a dict representation of a PipelineRunTrigger model
         pipeline_run_trigger_model = {}
         pipeline_run_trigger_model['name'] = 'Manual Trigger 1'
-        pipeline_run_trigger_model['properties'] = [property_model]
-        pipeline_run_trigger_model['secure_properties'] = [property_model]
+        pipeline_run_trigger_model['properties'] = {'anyKey': 'anyValue'}
+        pipeline_run_trigger_model['secure_properties'] = {'anyKey': 'anyValue'}
         pipeline_run_trigger_model['headers'] = {'anyKey': 'anyValue'}
         pipeline_run_trigger_model['body'] = {'anyKey': 'anyValue'}
 
         # Set up parameter values
         pipeline_id = '94619026-912b-4d92-8f51-6c74f0692d90'
         trigger_name = 'testString'
-        trigger_properties = [property_model]
-        secure_trigger_properties = [property_model]
+        trigger_properties = {'anyKey': 'anyValue'}
+        secure_trigger_properties = {'anyKey': 'anyValue'}
         trigger_headers = {'anyKey': 'anyValue'}
         trigger_body = {'anyKey': 'anyValue'}
         trigger = pipeline_run_trigger_model
@@ -4347,21 +4329,11 @@ class TestModel_PipelineRunTrigger:
         Test serialization/deserialization for PipelineRunTrigger
         """
 
-        # Construct dict forms of any model objects needed in order to build this model.
-
-        property_model = {}  # Property
-        property_model['name'] = 'testString'
-        property_model['value'] = 'testString'
-        property_model['href'] = 'testString'
-        property_model['enum'] = ['testString']
-        property_model['type'] = 'secure'
-        property_model['path'] = 'testString'
-
         # Construct a json representation of a PipelineRunTrigger model
         pipeline_run_trigger_model_json = {}
         pipeline_run_trigger_model_json['name'] = 'start-deploy'
-        pipeline_run_trigger_model_json['properties'] = [property_model]
-        pipeline_run_trigger_model_json['secure_properties'] = [property_model]
+        pipeline_run_trigger_model_json['properties'] = {'anyKey': 'anyValue'}
+        pipeline_run_trigger_model_json['secure_properties'] = {'anyKey': 'anyValue'}
         pipeline_run_trigger_model_json['headers'] = {'anyKey': 'anyValue'}
         pipeline_run_trigger_model_json['body'] = {'anyKey': 'anyValue'}
 


### PR DESCRIPTION
## PR summary
Attempting to trigger a PipelineRun with additional `properties` or `secureProperties` supplied results in an error creating the PipelineRun. Fix the format being used for the properties.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Attempting to trigger a PipelineRun with additional `properties` or `secureProperties` supplied will result in an error creating the PipelineRun. This is due to the wrong format being used for the properties, sending an Array instead of an Object.

## What is the new behavior?  
- Fix PipelineRun creation when supplying additional `properties` or `secureProperties`
- Update the integration test to account for this use case

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->