### PR TITLE
feat(toolchain): add text plain object property for create_toolchain_event function

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-08T21:38:51Z",
+  "generated_at": "2024-10-16T15:27:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
         "hashed_secret": "8d204a8e6f883c0691207b5eed52ab2889568f71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 145,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -80,18 +80,8 @@
         "hashed_secret": "adf43d5b527d744936011026242ec2e871752a85",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5885,
+        "line_number": 5787,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "test/integration/test_cd_toolchain_v2.py": [
-      {
-        "hashed_secret": "8d204a8e6f883c0691207b5eed52ab2889568f71",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 123,
-        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
@@ -100,7 +90,7 @@
         "hashed_secret": "3ba8ae817c7ee99cd1597bd5d364090ea0eaf85d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1424,
+        "line_number": 1554,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -108,7 +98,7 @@
         "hashed_secret": "e856e5396cf029b6c9f196fa1c4cc460e154da41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1428,
+        "line_number": 1562,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -116,7 +106,7 @@
         "hashed_secret": "e22f8b25cd663cc63cf88d5379c07b580005a261",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1432,
+        "line_number": 1570,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -124,7 +114,7 @@
         "hashed_secret": "448ea393cbfe519e2926c15a9aa0a077518909dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1439,
+        "line_number": 1580,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -132,7 +122,7 @@
         "hashed_secret": "bb7a5083b7b8ddccadad3d43fbc5688ec457e3f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1815,
+        "line_number": 2149,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -140,7 +130,7 @@
         "hashed_secret": "79558dd6187f15d53758f1f6a757873dbcf4f213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1819,
+        "line_number": 2157,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -148,7 +138,7 @@
         "hashed_secret": "4cc489408c48b8aea134d87caea7d721dde9aa2e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1823,
+        "line_number": 2165,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -156,13 +146,21 @@
         "hashed_secret": "8d204a8e6f883c0691207b5eed52ab2889568f71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1832,
+        "line_number": 2177,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b94de50d82724477b87cd86fb7a9de31d411516f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2196,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ]
   },
-  "version": "0.13.1+ibm.60.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/examples/test_cd_toolchain_v2_examples.py
+++ b/examples/test_cd_toolchain_v2_examples.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2023.
+# (C) Copyright IBM Corp. 2024.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ from ibm_continuous_delivery.cd_toolchain_v2 import *
 # in a configuration file and then:
 # export IBM_CREDENTIALS_FILE=<name of configuration file>
 #
-config_file = "cd_toolchain_v2.env"
+config_file = 'cd_toolchain_v2.env'
 
 cd_toolchain_service = None
 
@@ -58,7 +58,7 @@ class TestCdToolchainV2Examples:
     def setup_class(cls):
         global cd_toolchain_service
         if os.path.exists(config_file):
-            os.environ["IBM_CREDENTIALS_FILE"] = config_file
+            os.environ['IBM_CREDENTIALS_FILE'] = config_file
 
             # begin-common
 
@@ -71,11 +71,10 @@ class TestCdToolchainV2Examples:
             global config
             config = read_external_sources(CdToolchainV2.DEFAULT_SERVICE_NAME)
 
-        print("Setup complete.")
+        print('Setup complete.')
 
     needscredentials = pytest.mark.skipif(
-        not os.path.exists(config_file),
-        reason="External configuration not available, skipping...",
+        not os.path.exists(config_file), reason="External configuration not available, skipping..."
     )
 
     @needscredentials
@@ -85,12 +84,14 @@ class TestCdToolchainV2Examples:
         """
         try:
             global toolchain_id_link
-            print("\ncreate_toolchain() result:")
+
+            print('\ncreate_toolchain() result:')
+
             # begin-create_toolchain
 
             response = cd_toolchain_service.create_toolchain(
-                name="TestToolchainV2",
-                resource_group_id="6a9a01f2cff54a7f966f803d92877123",
+                name='TestToolchainV2',
+                resource_group_id='6a9a01f2cff54a7f966f803d92877123',
             )
             toolchain_post = response.get_result()
 
@@ -98,7 +99,7 @@ class TestCdToolchainV2Examples:
 
             # end-create_toolchain
 
-            toolchain_id_link = toolchain_post["id"]
+            toolchain_id_link = toolchain_post['id']
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -109,12 +110,14 @@ class TestCdToolchainV2Examples:
         """
         try:
             global tool_id_link
-            print("\ncreate_tool() result:")
+
+            print('\ncreate_tool() result:')
+
             # begin-create_tool
 
             response = cd_toolchain_service.create_tool(
                 toolchain_id=toolchain_id_link,
-                tool_type_id="draservicebroker",
+                tool_type_id='draservicebroker',
             )
             toolchain_tool_post = response.get_result()
 
@@ -122,7 +125,7 @@ class TestCdToolchainV2Examples:
 
             # end-create_tool
 
-            tool_id_link = toolchain_tool_post["id"]
+            tool_id_link = toolchain_tool_post['id']
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -132,15 +135,16 @@ class TestCdToolchainV2Examples:
         list_toolchains request example
         """
         try:
-            print("\nlist_toolchains() result:")
+            print('\nlist_toolchains() result:')
+
             # begin-list_toolchains
 
             all_results = []
             pager = ToolchainsPager(
                 client=cd_toolchain_service,
-                resource_group_id="6a9a01f2cff54a7f966f803d92877123",
+                resource_group_id='6a9a01f2cff54a7f966f803d92877123',
                 limit=10,
-                name="TestToolchainV2",
+                name='TestToolchainV2',
             )
             while pager.has_next():
                 next_page = pager.get_next()
@@ -159,7 +163,8 @@ class TestCdToolchainV2Examples:
         get_toolchain_by_id request example
         """
         try:
-            print("\nget_toolchain_by_id() result:")
+            print('\nget_toolchain_by_id() result:')
+
             # begin-get_toolchain_by_id
 
             response = cd_toolchain_service.get_toolchain_by_id(
@@ -180,7 +185,8 @@ class TestCdToolchainV2Examples:
         update_toolchain request example
         """
         try:
-            print("\nupdate_toolchain() result:")
+            print('\nupdate_toolchain() result:')
+
             # begin-update_toolchain
 
             toolchain_prototype_patch_model = {}
@@ -204,14 +210,15 @@ class TestCdToolchainV2Examples:
         create_toolchain_event request example
         """
         try:
-            print("\ncreate_toolchain_event() result:")
+            print('\ncreate_toolchain_event() result:')
+
             # begin-create_toolchain_event
 
             response = cd_toolchain_service.create_toolchain_event(
                 toolchain_id=toolchain_id_link,
-                title="My-custom-event",
-                description="This is my custom event",
-                content_type="application/json",
+                title='My-custom-event',
+                description='This is my custom event',
+                content_type='application/json',
             )
             toolchain_event_post = response.get_result()
 
@@ -228,7 +235,8 @@ class TestCdToolchainV2Examples:
         list_tools request example
         """
         try:
-            print("\nlist_tools() result:")
+            print('\nlist_tools() result:')
+
             # begin-list_tools
 
             all_results = []
@@ -254,7 +262,8 @@ class TestCdToolchainV2Examples:
         get_tool_by_id request example
         """
         try:
-            print("\nget_tool_by_id() result:")
+            print('\nget_tool_by_id() result:')
+
             # begin-get_tool_by_id
 
             response = cd_toolchain_service.get_tool_by_id(
@@ -276,7 +285,8 @@ class TestCdToolchainV2Examples:
         update_tool request example
         """
         try:
-            print("\nupdate_tool() result:")
+            print('\nupdate_tool() result:')
+
             # begin-update_tool
 
             toolchain_tool_prototype_patch_model = {}
@@ -309,7 +319,7 @@ class TestCdToolchainV2Examples:
             )
 
             # end-delete_tool
-            print("\ndelete_tool() response status code: ", response.get_status_code())
+            print('\ndelete_tool() response status code: ', response.get_status_code())
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -327,10 +337,7 @@ class TestCdToolchainV2Examples:
             )
 
             # end-delete_toolchain
-            print(
-                "\ndelete_toolchain() response status code: ",
-                response.get_status_code(),
-            )
+            print('\ndelete_toolchain() response status code: ', response.get_status_code())
 
         except ApiException as e:
             pytest.fail(str(e))

--- a/ibm_continuous_delivery/cd_toolchain_v2.py
+++ b/ibm_continuous_delivery/cd_toolchain_v2.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# (C) Copyright IBM Corp. 2023.
+# (C) Copyright IBM Corp. 2024.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,33 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.77.0-42417df0-20230811-192318
-
-"""
-This swagger document describes the options and endpoints of the Toolchain API.<br><br>
-All calls require an <strong>Authorization</strong> HTTP header to be set with a bearer
-token, which can be generated using the <a
-href="https://cloud.ibm.com/apidocs/iam-identity-token-api">Identity and Access Management
-(IAM) API</a>.<br><br>Note that all resources must have a corresponding
-<b>resource_group_id</b> to use the API, resources within a Cloud Foundry organization
-cannot be accessed or modified using the API.
-
-API Version: 2.0.0
-"""
+# IBM OpenAPI SDK Code Generator Version: 3.96.0-d6dec9d7-20241008-212902
 
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List
+from typing import Dict, List, Optional
 import json
 
 from ibm_cloud_sdk_core import BaseService, DetailedResponse
 from ibm_cloud_sdk_core.authenticators.authenticator import Authenticator
 from ibm_cloud_sdk_core.get_authenticator import get_authenticator_from_environment
-from ibm_cloud_sdk_core.utils import (
-    convert_model,
-    datetime_to_string,
-    string_to_datetime,
-)
+from ibm_cloud_sdk_core.utils import convert_model, datetime_to_string, string_to_datetime
 
 from .common import get_sdk_headers
 
@@ -52,27 +36,27 @@ from .common import get_sdk_headers
 class CdToolchainV2(BaseService):
     """The CD Toolchain V2 service."""
 
-    DEFAULT_SERVICE_URL = "https://api.us-south.devops.cloud.ibm.com/toolchain/v2"
-    DEFAULT_SERVICE_NAME = "cd_toolchain"
+    DEFAULT_SERVICE_URL = 'https://api.us-south.devops.cloud.ibm.com/toolchain/v2'
+    DEFAULT_SERVICE_NAME = 'cd_toolchain'
 
     REGIONAL_ENDPOINTS = {
-        "us-south": "https://api.us-south.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the us-south region
-        "us-east": "https://api.us-east.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the us-east region
-        "eu-de": "https://api.eu-de.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the eu-de region
-        "eu-gb": "https://api.eu-gb.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the eu-gb region
-        "jp-osa": "https://api.jp-osa.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the jp-osa region
-        "jp-tok": "https://api.jp-tok.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the jp-tok region
-        "au-syd": "https://api.au-syd.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the au-syd region
-        "ca-tor": "https://api.ca-tor.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the ca-tor region
-        "br-sao": "https://api.br-sao.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the br-sao region
-        "eu-es": "https://api.eu-es.devops.cloud.ibm.com/toolchain/v2",  # The toolchain API endpoint in the eu-es region
+        'us-south': 'https://api.us-south.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the us-south region
+        'us-east': 'https://api.us-east.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the us-east region
+        'eu-de': 'https://api.eu-de.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the eu-de region
+        'eu-gb': 'https://api.eu-gb.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the eu-gb region
+        'jp-osa': 'https://api.jp-osa.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the jp-osa region
+        'jp-tok': 'https://api.jp-tok.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the jp-tok region
+        'au-syd': 'https://api.au-syd.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the au-syd region
+        'ca-tor': 'https://api.ca-tor.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the ca-tor region
+        'br-sao': 'https://api.br-sao.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the br-sao region
+        'eu-es': 'https://api.eu-es.devops.cloud.ibm.com/toolchain/v2',  # The toolchain API endpoint in the eu-es region
     }
 
     @classmethod
     def new_instance(
         cls,
         service_name: str = DEFAULT_SERVICE_NAME,
-    ) -> "CdToolchainV2":
+    ) -> 'CdToolchainV2':
         """
         Return a new client for the CD Toolchain service using the specified
                parameters and external configuration.
@@ -117,9 +101,9 @@ class CdToolchainV2(BaseService):
         self,
         resource_group_id: str,
         *,
-        limit: int = None,
-        start: str = None,
-        name: str = None,
+        limit: Optional[int] = None,
+        start: Optional[str] = None,
+        name: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -140,30 +124,30 @@ class CdToolchainV2(BaseService):
         """
 
         if not resource_group_id:
-            raise ValueError("resource_group_id must be provided")
+            raise ValueError('resource_group_id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="list_toolchains",
+            service_version='V2',
+            operation_id='list_toolchains',
         )
         headers.update(sdk_headers)
 
         params = {
-            "resource_group_id": resource_group_id,
-            "limit": limit,
-            "start": start,
-            "name": name,
+            'resource_group_id': resource_group_id,
+            'limit': limit,
+            'start': start,
+            'name': name,
         }
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
-        headers["Accept"] = "application/json"
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
 
-        url = "/toolchains"
+        url = '/toolchains'
         request = self.prepare_request(
-            method="GET",
+            method='GET',
             url=url,
             headers=headers,
             params=params,
@@ -177,7 +161,7 @@ class CdToolchainV2(BaseService):
         name: str,
         resource_group_id: str,
         *,
-        description: str = None,
+        description: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -195,34 +179,34 @@ class CdToolchainV2(BaseService):
         """
 
         if name is None:
-            raise ValueError("name must be provided")
+            raise ValueError('name must be provided')
         if resource_group_id is None:
-            raise ValueError("resource_group_id must be provided")
+            raise ValueError('resource_group_id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="create_toolchain",
+            service_version='V2',
+            operation_id='create_toolchain',
         )
         headers.update(sdk_headers)
 
         data = {
-            "name": name,
-            "resource_group_id": resource_group_id,
-            "description": description,
+            'name': name,
+            'resource_group_id': resource_group_id,
+            'description': description,
         }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
-        headers["content-type"] = "application/json"
+        headers['content-type'] = 'application/json'
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
-        headers["Accept"] = "application/json"
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
 
-        url = "/toolchains"
+        url = '/toolchains'
         request = self.prepare_request(
-            method="POST",
+            method='POST',
             url=url,
             headers=headers,
             data=data,
@@ -248,26 +232,26 @@ class CdToolchainV2(BaseService):
         """
 
         if not toolchain_id:
-            raise ValueError("toolchain_id must be provided")
+            raise ValueError('toolchain_id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="get_toolchain_by_id",
+            service_version='V2',
+            operation_id='get_toolchain_by_id',
         )
         headers.update(sdk_headers)
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
-        headers["Accept"] = "application/json"
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
 
-        path_param_keys = ["toolchain_id"]
+        path_param_keys = ['toolchain_id']
         path_param_values = self.encode_path_vars(toolchain_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = "/toolchains/{toolchain_id}".format(**path_param_dict)
+        url = '/toolchains/{toolchain_id}'.format(**path_param_dict)
         request = self.prepare_request(
-            method="GET",
+            method='GET',
             url=url,
             headers=headers,
         )
@@ -292,25 +276,25 @@ class CdToolchainV2(BaseService):
         """
 
         if not toolchain_id:
-            raise ValueError("toolchain_id must be provided")
+            raise ValueError('toolchain_id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="delete_toolchain",
+            service_version='V2',
+            operation_id='delete_toolchain',
         )
         headers.update(sdk_headers)
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
-        path_param_keys = ["toolchain_id"]
+        path_param_keys = ['toolchain_id']
         path_param_values = self.encode_path_vars(toolchain_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = "/toolchains/{toolchain_id}".format(**path_param_dict)
+        url = '/toolchains/{toolchain_id}'.format(**path_param_dict)
         request = self.prepare_request(
-            method="DELETE",
+            method='DELETE',
             url=url,
             headers=headers,
         )
@@ -321,7 +305,7 @@ class CdToolchainV2(BaseService):
     def update_toolchain(
         self,
         toolchain_id: str,
-        toolchain_prototype_patch: "ToolchainPrototypePatch",
+        toolchain_prototype_patch: 'ToolchainPrototypePatch',
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -337,33 +321,33 @@ class CdToolchainV2(BaseService):
         """
 
         if not toolchain_id:
-            raise ValueError("toolchain_id must be provided")
+            raise ValueError('toolchain_id must be provided')
         if toolchain_prototype_patch is None:
-            raise ValueError("toolchain_prototype_patch must be provided")
+            raise ValueError('toolchain_prototype_patch must be provided')
         if isinstance(toolchain_prototype_patch, ToolchainPrototypePatch):
             toolchain_prototype_patch = convert_model(toolchain_prototype_patch)
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="update_toolchain",
+            service_version='V2',
+            operation_id='update_toolchain',
         )
         headers.update(sdk_headers)
 
         data = json.dumps(toolchain_prototype_patch)
-        headers["content-type"] = "application/merge-patch+json"
+        headers['content-type'] = 'application/merge-patch+json'
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
-        headers["Accept"] = "application/json"
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
 
-        path_param_keys = ["toolchain_id"]
+        path_param_keys = ['toolchain_id']
         path_param_values = self.encode_path_vars(toolchain_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = "/toolchains/{toolchain_id}".format(**path_param_dict)
+        url = '/toolchains/{toolchain_id}'.format(**path_param_dict)
         request = self.prepare_request(
-            method="PATCH",
+            method='PATCH',
             url=url,
             headers=headers,
             data=data,
@@ -379,14 +363,15 @@ class CdToolchainV2(BaseService):
         description: str,
         content_type: str,
         *,
-        data: "ToolchainEventPrototypeData" = None,
+        data: Optional['ToolchainEventPrototypeData'] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
         Create a toolchain event.
 
-        Creates and sends a custom event to Event Notifications. This requires an Event
-        Notification tool. This method is BETA and subject to change.
+        Creates and sends a custom event to each Event Notifications instance configured
+        as a tool into the toolchain. This operation will fail if no Event Notifications
+        instances are configured into the toolchain.
 
         :param str toolchain_id: ID of the toolchain to send events from.
         :param str title: Event title.
@@ -402,44 +387,44 @@ class CdToolchainV2(BaseService):
         """
 
         if not toolchain_id:
-            raise ValueError("toolchain_id must be provided")
+            raise ValueError('toolchain_id must be provided')
         if title is None:
-            raise ValueError("title must be provided")
+            raise ValueError('title must be provided')
         if description is None:
-            raise ValueError("description must be provided")
+            raise ValueError('description must be provided')
         if content_type is None:
-            raise ValueError("content_type must be provided")
+            raise ValueError('content_type must be provided')
         if data is not None:
             data = convert_model(data)
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="create_toolchain_event",
+            service_version='V2',
+            operation_id='create_toolchain_event',
         )
         headers.update(sdk_headers)
 
         data = {
-            "title": title,
-            "description": description,
-            "content_type": content_type,
-            "data": data,
+            'title': title,
+            'description': description,
+            'content_type': content_type,
+            'data': data,
         }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
-        headers["content-type"] = "application/json"
+        headers['content-type'] = 'application/json'
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
-        headers["Accept"] = "application/json"
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
 
-        path_param_keys = ["toolchain_id"]
+        path_param_keys = ['toolchain_id']
         path_param_values = self.encode_path_vars(toolchain_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = "/toolchains/{toolchain_id}/events".format(**path_param_dict)
+        url = '/toolchains/{toolchain_id}/events'.format(**path_param_dict)
         request = self.prepare_request(
-            method="POST",
+            method='POST',
             url=url,
             headers=headers,
             data=data,
@@ -456,8 +441,8 @@ class CdToolchainV2(BaseService):
         self,
         toolchain_id: str,
         *,
-        limit: int = None,
-        start: str = None,
+        limit: Optional[int] = None,
+        start: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -475,31 +460,31 @@ class CdToolchainV2(BaseService):
         """
 
         if not toolchain_id:
-            raise ValueError("toolchain_id must be provided")
+            raise ValueError('toolchain_id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="list_tools",
+            service_version='V2',
+            operation_id='list_tools',
         )
         headers.update(sdk_headers)
 
         params = {
-            "limit": limit,
-            "start": start,
+            'limit': limit,
+            'start': start,
         }
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
-        headers["Accept"] = "application/json"
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
 
-        path_param_keys = ["toolchain_id"]
+        path_param_keys = ['toolchain_id']
         path_param_values = self.encode_path_vars(toolchain_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = "/toolchains/{toolchain_id}/tools".format(**path_param_dict)
+        url = '/toolchains/{toolchain_id}/tools'.format(**path_param_dict)
         request = self.prepare_request(
-            method="GET",
+            method='GET',
             url=url,
             headers=headers,
             params=params,
@@ -513,8 +498,8 @@ class CdToolchainV2(BaseService):
         toolchain_id: str,
         tool_type_id: str,
         *,
-        name: str = None,
-        parameters: dict = None,
+        name: Optional[str] = None,
+        parameters: Optional[dict] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -541,37 +526,37 @@ class CdToolchainV2(BaseService):
         """
 
         if not toolchain_id:
-            raise ValueError("toolchain_id must be provided")
+            raise ValueError('toolchain_id must be provided')
         if tool_type_id is None:
-            raise ValueError("tool_type_id must be provided")
+            raise ValueError('tool_type_id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="create_tool",
+            service_version='V2',
+            operation_id='create_tool',
         )
         headers.update(sdk_headers)
 
         data = {
-            "tool_type_id": tool_type_id,
-            "name": name,
-            "parameters": parameters,
+            'tool_type_id': tool_type_id,
+            'name': name,
+            'parameters': parameters,
         }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
-        headers["content-type"] = "application/json"
+        headers['content-type'] = 'application/json'
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
-        headers["Accept"] = "application/json"
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
 
-        path_param_keys = ["toolchain_id"]
+        path_param_keys = ['toolchain_id']
         path_param_values = self.encode_path_vars(toolchain_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = "/toolchains/{toolchain_id}/tools".format(**path_param_dict)
+        url = '/toolchains/{toolchain_id}/tools'.format(**path_param_dict)
         request = self.prepare_request(
-            method="POST",
+            method='POST',
             url=url,
             headers=headers,
             data=data,
@@ -599,28 +584,28 @@ class CdToolchainV2(BaseService):
         """
 
         if not toolchain_id:
-            raise ValueError("toolchain_id must be provided")
+            raise ValueError('toolchain_id must be provided')
         if not tool_id:
-            raise ValueError("tool_id must be provided")
+            raise ValueError('tool_id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="get_tool_by_id",
+            service_version='V2',
+            operation_id='get_tool_by_id',
         )
         headers.update(sdk_headers)
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
-        headers["Accept"] = "application/json"
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
 
-        path_param_keys = ["toolchain_id", "tool_id"]
+        path_param_keys = ['toolchain_id', 'tool_id']
         path_param_values = self.encode_path_vars(toolchain_id, tool_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = "/toolchains/{toolchain_id}/tools/{tool_id}".format(**path_param_dict)
+        url = '/toolchains/{toolchain_id}/tools/{tool_id}'.format(**path_param_dict)
         request = self.prepare_request(
-            method="GET",
+            method='GET',
             url=url,
             headers=headers,
         )
@@ -647,27 +632,27 @@ class CdToolchainV2(BaseService):
         """
 
         if not toolchain_id:
-            raise ValueError("toolchain_id must be provided")
+            raise ValueError('toolchain_id must be provided')
         if not tool_id:
-            raise ValueError("tool_id must be provided")
+            raise ValueError('tool_id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="delete_tool",
+            service_version='V2',
+            operation_id='delete_tool',
         )
         headers.update(sdk_headers)
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
-        path_param_keys = ["toolchain_id", "tool_id"]
+        path_param_keys = ['toolchain_id', 'tool_id']
         path_param_values = self.encode_path_vars(toolchain_id, tool_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = "/toolchains/{toolchain_id}/tools/{tool_id}".format(**path_param_dict)
+        url = '/toolchains/{toolchain_id}/tools/{tool_id}'.format(**path_param_dict)
         request = self.prepare_request(
-            method="DELETE",
+            method='DELETE',
             url=url,
             headers=headers,
         )
@@ -679,7 +664,7 @@ class CdToolchainV2(BaseService):
         self,
         toolchain_id: str,
         tool_id: str,
-        toolchain_tool_prototype_patch: "ToolchainToolPrototypePatch",
+        toolchain_tool_prototype_patch: 'ToolchainToolPrototypePatch',
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -696,35 +681,35 @@ class CdToolchainV2(BaseService):
         """
 
         if not toolchain_id:
-            raise ValueError("toolchain_id must be provided")
+            raise ValueError('toolchain_id must be provided')
         if not tool_id:
-            raise ValueError("tool_id must be provided")
+            raise ValueError('tool_id must be provided')
         if toolchain_tool_prototype_patch is None:
-            raise ValueError("toolchain_tool_prototype_patch must be provided")
+            raise ValueError('toolchain_tool_prototype_patch must be provided')
         if isinstance(toolchain_tool_prototype_patch, ToolchainToolPrototypePatch):
             toolchain_tool_prototype_patch = convert_model(toolchain_tool_prototype_patch)
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
-            service_version="V2",
-            operation_id="update_tool",
+            service_version='V2',
+            operation_id='update_tool',
         )
         headers.update(sdk_headers)
 
         data = json.dumps(toolchain_tool_prototype_patch)
-        headers["content-type"] = "application/merge-patch+json"
+        headers['content-type'] = 'application/merge-patch+json'
 
-        if "headers" in kwargs:
-            headers.update(kwargs.get("headers"))
-            del kwargs["headers"]
-        headers["Accept"] = "application/json"
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
 
-        path_param_keys = ["toolchain_id", "tool_id"]
+        path_param_keys = ['toolchain_id', 'tool_id']
         path_param_values = self.encode_path_vars(toolchain_id, tool_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = "/toolchains/{toolchain_id}/tools/{tool_id}".format(**path_param_dict)
+        url = '/toolchains/{toolchain_id}/tools/{tool_id}'.format(**path_param_dict)
         request = self.prepare_request(
-            method="PATCH",
+            method='PATCH',
             url=url,
             headers=headers,
             data=data,
@@ -743,27 +728,27 @@ class ToolModel:
     """
     Model describing tool resource.
 
-    :attr str id: Tool ID.
-    :attr str resource_group_id: Resource group where the tool is located.
-    :attr str crn: Tool CRN.
-    :attr str tool_type_id: The unique name of the provisioned tool. A table of
+    :param str id: Tool ID.
+    :param str resource_group_id: Resource group where the tool is located.
+    :param str crn: Tool CRN.
+    :param str tool_type_id: The unique name of the provisioned tool. A table of
           `tool_type_id` values corresponding to each tool integration can be found in the
           <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
-    :attr str toolchain_id: ID of toolchain which the tool is bound to.
-    :attr str toolchain_crn: CRN of toolchain which the tool is bound to.
-    :attr str href: URI representing the tool.
-    :attr ToolModelReferent referent: Information on URIs to access this resource
+    :param str toolchain_id: ID of toolchain which the tool is bound to.
+    :param str toolchain_crn: CRN of toolchain which the tool is bound to.
+    :param str href: URI representing the tool.
+    :param ToolModelReferent referent: Information on URIs to access this resource
           through the UI or API.
-    :attr str name: (optional) Name of the tool.
-    :attr datetime updated_at: Latest tool update timestamp.
-    :attr dict parameters: Unique key-value pairs representing parameters to be used
-          to create the tool. A list of parameters for each tool integration can be found
-          in the <a
+    :param str name: (optional) Name of the tool.
+    :param datetime updated_at: Latest tool update timestamp.
+    :param dict parameters: Unique key-value pairs representing parameters to be
+          used to create the tool. A list of parameters for each tool integration can be
+          found in the <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
-    :attr str state: Current configuration state of the tool.
+    :param str state: Current configuration state of the tool.
     """
 
     def __init__(
@@ -775,12 +760,12 @@ class ToolModel:
         toolchain_id: str,
         toolchain_crn: str,
         href: str,
-        referent: "ToolModelReferent",
+        referent: 'ToolModelReferent',
         updated_at: datetime,
         parameters: dict,
         state: str,
         *,
-        name: str = None,
+        name: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolModel object.
@@ -821,55 +806,55 @@ class ToolModel:
         self.state = state
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolModel":
+    def from_dict(cls, _dict: Dict) -> 'ToolModel':
         """Initialize a ToolModel object from a json dictionary."""
         args = {}
-        if "id" in _dict:
-            args["id"] = _dict.get("id")
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
         else:
-            raise ValueError("Required property 'id' not present in ToolModel JSON")
-        if "resource_group_id" in _dict:
-            args["resource_group_id"] = _dict.get("resource_group_id")
+            raise ValueError('Required property \'id\' not present in ToolModel JSON')
+        if (resource_group_id := _dict.get('resource_group_id')) is not None:
+            args['resource_group_id'] = resource_group_id
         else:
-            raise ValueError("Required property 'resource_group_id' not present in ToolModel JSON")
-        if "crn" in _dict:
-            args["crn"] = _dict.get("crn")
+            raise ValueError('Required property \'resource_group_id\' not present in ToolModel JSON')
+        if (crn := _dict.get('crn')) is not None:
+            args['crn'] = crn
         else:
-            raise ValueError("Required property 'crn' not present in ToolModel JSON")
-        if "tool_type_id" in _dict:
-            args["tool_type_id"] = _dict.get("tool_type_id")
+            raise ValueError('Required property \'crn\' not present in ToolModel JSON')
+        if (tool_type_id := _dict.get('tool_type_id')) is not None:
+            args['tool_type_id'] = tool_type_id
         else:
-            raise ValueError("Required property 'tool_type_id' not present in ToolModel JSON")
-        if "toolchain_id" in _dict:
-            args["toolchain_id"] = _dict.get("toolchain_id")
+            raise ValueError('Required property \'tool_type_id\' not present in ToolModel JSON')
+        if (toolchain_id := _dict.get('toolchain_id')) is not None:
+            args['toolchain_id'] = toolchain_id
         else:
-            raise ValueError("Required property 'toolchain_id' not present in ToolModel JSON")
-        if "toolchain_crn" in _dict:
-            args["toolchain_crn"] = _dict.get("toolchain_crn")
+            raise ValueError('Required property \'toolchain_id\' not present in ToolModel JSON')
+        if (toolchain_crn := _dict.get('toolchain_crn')) is not None:
+            args['toolchain_crn'] = toolchain_crn
         else:
-            raise ValueError("Required property 'toolchain_crn' not present in ToolModel JSON")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+            raise ValueError('Required property \'toolchain_crn\' not present in ToolModel JSON')
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolModel JSON")
-        if "referent" in _dict:
-            args["referent"] = ToolModelReferent.from_dict(_dict.get("referent"))
+            raise ValueError('Required property \'href\' not present in ToolModel JSON')
+        if (referent := _dict.get('referent')) is not None:
+            args['referent'] = ToolModelReferent.from_dict(referent)
         else:
-            raise ValueError("Required property 'referent' not present in ToolModel JSON")
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
-        if "updated_at" in _dict:
-            args["updated_at"] = string_to_datetime(_dict.get("updated_at"))
+            raise ValueError('Required property \'referent\' not present in ToolModel JSON')
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
+        if (updated_at := _dict.get('updated_at')) is not None:
+            args['updated_at'] = string_to_datetime(updated_at)
         else:
-            raise ValueError("Required property 'updated_at' not present in ToolModel JSON")
-        if "parameters" in _dict:
-            args["parameters"] = _dict.get("parameters")
+            raise ValueError('Required property \'updated_at\' not present in ToolModel JSON')
+        if (parameters := _dict.get('parameters')) is not None:
+            args['parameters'] = parameters
         else:
-            raise ValueError("Required property 'parameters' not present in ToolModel JSON")
-        if "state" in _dict:
-            args["state"] = _dict.get("state")
+            raise ValueError('Required property \'parameters\' not present in ToolModel JSON')
+        if (state := _dict.get('state')) is not None:
+            args['state'] = state
         else:
-            raise ValueError("Required property 'state' not present in ToolModel JSON")
+            raise ValueError('Required property \'state\' not present in ToolModel JSON')
         return cls(**args)
 
     @classmethod
@@ -880,33 +865,33 @@ class ToolModel:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "id") and self.id is not None:
-            _dict["id"] = self.id
-        if hasattr(self, "resource_group_id") and self.resource_group_id is not None:
-            _dict["resource_group_id"] = self.resource_group_id
-        if hasattr(self, "crn") and self.crn is not None:
-            _dict["crn"] = self.crn
-        if hasattr(self, "tool_type_id") and self.tool_type_id is not None:
-            _dict["tool_type_id"] = self.tool_type_id
-        if hasattr(self, "toolchain_id") and self.toolchain_id is not None:
-            _dict["toolchain_id"] = self.toolchain_id
-        if hasattr(self, "toolchain_crn") and self.toolchain_crn is not None:
-            _dict["toolchain_crn"] = self.toolchain_crn
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
-        if hasattr(self, "referent") and self.referent is not None:
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'resource_group_id') and self.resource_group_id is not None:
+            _dict['resource_group_id'] = self.resource_group_id
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'tool_type_id') and self.tool_type_id is not None:
+            _dict['tool_type_id'] = self.tool_type_id
+        if hasattr(self, 'toolchain_id') and self.toolchain_id is not None:
+            _dict['toolchain_id'] = self.toolchain_id
+        if hasattr(self, 'toolchain_crn') and self.toolchain_crn is not None:
+            _dict['toolchain_crn'] = self.toolchain_crn
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
+        if hasattr(self, 'referent') and self.referent is not None:
             if isinstance(self.referent, dict):
-                _dict["referent"] = self.referent
+                _dict['referent'] = self.referent
             else:
-                _dict["referent"] = self.referent.to_dict()
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "updated_at") and self.updated_at is not None:
-            _dict["updated_at"] = datetime_to_string(self.updated_at)
-        if hasattr(self, "parameters") and self.parameters is not None:
-            _dict["parameters"] = self.parameters
-        if hasattr(self, "state") and self.state is not None:
-            _dict["state"] = self.state
+                _dict['referent'] = self.referent.to_dict()
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'updated_at') and self.updated_at is not None:
+            _dict['updated_at'] = datetime_to_string(self.updated_at)
+        if hasattr(self, 'parameters') and self.parameters is not None:
+            _dict['parameters'] = self.parameters
+        if hasattr(self, 'state') and self.state is not None:
+            _dict['state'] = self.state
         return _dict
 
     def _to_dict(self):
@@ -917,13 +902,13 @@ class ToolModel:
         """Return a `str` version of this ToolModel object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolModel") -> bool:
+    def __eq__(self, other: 'ToolModel') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolModel") -> bool:
+    def __ne__(self, other: 'ToolModel') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -932,25 +917,25 @@ class ToolModel:
         Current configuration state of the tool.
         """
 
-        CONFIGURED = "configured"
-        CONFIGURING = "configuring"
-        MISCONFIGURED = "misconfigured"
-        UNCONFIGURED = "unconfigured"
+        CONFIGURED = 'configured'
+        CONFIGURING = 'configuring'
+        MISCONFIGURED = 'misconfigured'
+        UNCONFIGURED = 'unconfigured'
 
 
 class ToolModelReferent:
     """
     Information on URIs to access this resource through the UI or API.
 
-    :attr str ui_href: (optional) URI representing this resource through the UI.
-    :attr str api_href: (optional) URI representing this resource through an API.
+    :param str ui_href: (optional) URI representing this resource through the UI.
+    :param str api_href: (optional) URI representing this resource through an API.
     """
 
     def __init__(
         self,
         *,
-        ui_href: str = None,
-        api_href: str = None,
+        ui_href: Optional[str] = None,
+        api_href: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolModelReferent object.
@@ -964,13 +949,13 @@ class ToolModelReferent:
         self.api_href = api_href
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolModelReferent":
+    def from_dict(cls, _dict: Dict) -> 'ToolModelReferent':
         """Initialize a ToolModelReferent object from a json dictionary."""
         args = {}
-        if "ui_href" in _dict:
-            args["ui_href"] = _dict.get("ui_href")
-        if "api_href" in _dict:
-            args["api_href"] = _dict.get("api_href")
+        if (ui_href := _dict.get('ui_href')) is not None:
+            args['ui_href'] = ui_href
+        if (api_href := _dict.get('api_href')) is not None:
+            args['api_href'] = api_href
         return cls(**args)
 
     @classmethod
@@ -981,10 +966,10 @@ class ToolModelReferent:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "ui_href") and self.ui_href is not None:
-            _dict["ui_href"] = self.ui_href
-        if hasattr(self, "api_href") and self.api_href is not None:
-            _dict["api_href"] = self.api_href
+        if hasattr(self, 'ui_href') and self.ui_href is not None:
+            _dict['ui_href'] = self.ui_href
+        if hasattr(self, 'api_href') and self.api_href is not None:
+            _dict['api_href'] = self.api_href
         return _dict
 
     def _to_dict(self):
@@ -995,13 +980,13 @@ class ToolModelReferent:
         """Return a `str` version of this ToolModelReferent object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolModelReferent") -> bool:
+    def __eq__(self, other: 'ToolModelReferent') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolModelReferent") -> bool:
+    def __ne__(self, other: 'ToolModelReferent') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1010,18 +995,18 @@ class Toolchain:
     """
     Response structure for GET toolchains.
 
-    :attr str id: Toolchain ID.
-    :attr str name: Toolchain name.
-    :attr str description: Describes the toolchain.
-    :attr str account_id: Account ID where toolchain can be found.
-    :attr str location: Toolchain region.
-    :attr str resource_group_id: Resource group where the toolchain is located.
-    :attr str crn: Toolchain CRN.
-    :attr str href: URI that can be used to retrieve toolchain.
-    :attr str ui_href: URL of a user-facing user interface for this toolchain.
-    :attr datetime created_at: Toolchain creation timestamp.
-    :attr datetime updated_at: Latest toolchain update timestamp.
-    :attr str created_by: Identity that created the toolchain.
+    :param str id: Toolchain ID.
+    :param str name: Toolchain name.
+    :param str description: Describes the toolchain.
+    :param str account_id: Account ID where toolchain can be found.
+    :param str location: Toolchain region.
+    :param str resource_group_id: Resource group where the toolchain is located.
+    :param str crn: Toolchain CRN.
+    :param str href: URI that can be used to retrieve toolchain.
+    :param str ui_href: URL of a user-facing user interface for this toolchain.
+    :param datetime created_at: Toolchain creation timestamp.
+    :param datetime updated_at: Latest toolchain update timestamp.
+    :param str created_by: Identity that created the toolchain.
     """
 
     def __init__(
@@ -1070,57 +1055,57 @@ class Toolchain:
         self.created_by = created_by
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "Toolchain":
+    def from_dict(cls, _dict: Dict) -> 'Toolchain':
         """Initialize a Toolchain object from a json dictionary."""
         args = {}
-        if "id" in _dict:
-            args["id"] = _dict.get("id")
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
         else:
-            raise ValueError("Required property 'id' not present in Toolchain JSON")
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
+            raise ValueError('Required property \'id\' not present in Toolchain JSON')
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
         else:
-            raise ValueError("Required property 'name' not present in Toolchain JSON")
-        if "description" in _dict:
-            args["description"] = _dict.get("description")
+            raise ValueError('Required property \'name\' not present in Toolchain JSON')
+        if (description := _dict.get('description')) is not None:
+            args['description'] = description
         else:
-            raise ValueError("Required property 'description' not present in Toolchain JSON")
-        if "account_id" in _dict:
-            args["account_id"] = _dict.get("account_id")
+            raise ValueError('Required property \'description\' not present in Toolchain JSON')
+        if (account_id := _dict.get('account_id')) is not None:
+            args['account_id'] = account_id
         else:
-            raise ValueError("Required property 'account_id' not present in Toolchain JSON")
-        if "location" in _dict:
-            args["location"] = _dict.get("location")
+            raise ValueError('Required property \'account_id\' not present in Toolchain JSON')
+        if (location := _dict.get('location')) is not None:
+            args['location'] = location
         else:
-            raise ValueError("Required property 'location' not present in Toolchain JSON")
-        if "resource_group_id" in _dict:
-            args["resource_group_id"] = _dict.get("resource_group_id")
+            raise ValueError('Required property \'location\' not present in Toolchain JSON')
+        if (resource_group_id := _dict.get('resource_group_id')) is not None:
+            args['resource_group_id'] = resource_group_id
         else:
-            raise ValueError("Required property 'resource_group_id' not present in Toolchain JSON")
-        if "crn" in _dict:
-            args["crn"] = _dict.get("crn")
+            raise ValueError('Required property \'resource_group_id\' not present in Toolchain JSON')
+        if (crn := _dict.get('crn')) is not None:
+            args['crn'] = crn
         else:
-            raise ValueError("Required property 'crn' not present in Toolchain JSON")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+            raise ValueError('Required property \'crn\' not present in Toolchain JSON')
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in Toolchain JSON")
-        if "ui_href" in _dict:
-            args["ui_href"] = _dict.get("ui_href")
+            raise ValueError('Required property \'href\' not present in Toolchain JSON')
+        if (ui_href := _dict.get('ui_href')) is not None:
+            args['ui_href'] = ui_href
         else:
-            raise ValueError("Required property 'ui_href' not present in Toolchain JSON")
-        if "created_at" in _dict:
-            args["created_at"] = string_to_datetime(_dict.get("created_at"))
+            raise ValueError('Required property \'ui_href\' not present in Toolchain JSON')
+        if (created_at := _dict.get('created_at')) is not None:
+            args['created_at'] = string_to_datetime(created_at)
         else:
-            raise ValueError("Required property 'created_at' not present in Toolchain JSON")
-        if "updated_at" in _dict:
-            args["updated_at"] = string_to_datetime(_dict.get("updated_at"))
+            raise ValueError('Required property \'created_at\' not present in Toolchain JSON')
+        if (updated_at := _dict.get('updated_at')) is not None:
+            args['updated_at'] = string_to_datetime(updated_at)
         else:
-            raise ValueError("Required property 'updated_at' not present in Toolchain JSON")
-        if "created_by" in _dict:
-            args["created_by"] = _dict.get("created_by")
+            raise ValueError('Required property \'updated_at\' not present in Toolchain JSON')
+        if (created_by := _dict.get('created_by')) is not None:
+            args['created_by'] = created_by
         else:
-            raise ValueError("Required property 'created_by' not present in Toolchain JSON")
+            raise ValueError('Required property \'created_by\' not present in Toolchain JSON')
         return cls(**args)
 
     @classmethod
@@ -1131,30 +1116,30 @@ class Toolchain:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "id") and self.id is not None:
-            _dict["id"] = self.id
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "description") and self.description is not None:
-            _dict["description"] = self.description
-        if hasattr(self, "account_id") and self.account_id is not None:
-            _dict["account_id"] = self.account_id
-        if hasattr(self, "location") and self.location is not None:
-            _dict["location"] = self.location
-        if hasattr(self, "resource_group_id") and self.resource_group_id is not None:
-            _dict["resource_group_id"] = self.resource_group_id
-        if hasattr(self, "crn") and self.crn is not None:
-            _dict["crn"] = self.crn
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
-        if hasattr(self, "ui_href") and self.ui_href is not None:
-            _dict["ui_href"] = self.ui_href
-        if hasattr(self, "created_at") and self.created_at is not None:
-            _dict["created_at"] = datetime_to_string(self.created_at)
-        if hasattr(self, "updated_at") and self.updated_at is not None:
-            _dict["updated_at"] = datetime_to_string(self.updated_at)
-        if hasattr(self, "created_by") and self.created_by is not None:
-            _dict["created_by"] = self.created_by
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'account_id') and self.account_id is not None:
+            _dict['account_id'] = self.account_id
+        if hasattr(self, 'location') and self.location is not None:
+            _dict['location'] = self.location
+        if hasattr(self, 'resource_group_id') and self.resource_group_id is not None:
+            _dict['resource_group_id'] = self.resource_group_id
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
+        if hasattr(self, 'ui_href') and self.ui_href is not None:
+            _dict['ui_href'] = self.ui_href
+        if hasattr(self, 'created_at') and self.created_at is not None:
+            _dict['created_at'] = datetime_to_string(self.created_at)
+        if hasattr(self, 'updated_at') and self.updated_at is not None:
+            _dict['updated_at'] = datetime_to_string(self.updated_at)
+        if hasattr(self, 'created_by') and self.created_by is not None:
+            _dict['created_by'] = self.created_by
         return _dict
 
     def _to_dict(self):
@@ -1165,13 +1150,13 @@ class Toolchain:
         """Return a `str` version of this Toolchain object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "Toolchain") -> bool:
+    def __eq__(self, other: 'Toolchain') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "Toolchain") -> bool:
+    def __ne__(self, other: 'Toolchain') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1180,17 +1165,17 @@ class ToolchainCollection:
     """
     Response structure for GET toolchains.
 
-    :attr int total_count: Total number of toolchains found in collection.
-    :attr int limit: Maximum number of toolchains returned from collection.
-    :attr ToolchainCollectionFirst first: Information about retrieving first
+    :param int total_count: Total number of toolchains found in collection.
+    :param int limit: Maximum number of toolchains returned from collection.
+    :param ToolchainCollectionFirst first: Information about retrieving first
           toolchain results from the collection.
-    :attr ToolchainCollectionPrevious previous: (optional) Information about
+    :param ToolchainCollectionPrevious previous: (optional) Information about
           retrieving previous toolchain results from the collection.
-    :attr ToolchainCollectionNext next: (optional) Information about retrieving next
-          toolchain results from the collection.
-    :attr ToolchainCollectionLast last: Information about retrieving last toolchain
+    :param ToolchainCollectionNext next: (optional) Information about retrieving
+          next toolchain results from the collection.
+    :param ToolchainCollectionLast last: Information about retrieving last toolchain
           results from the collection.
-    :attr List[ToolchainModel] toolchains: (optional) Toolchain results returned
+    :param List[ToolchainModel] toolchains: (optional) Toolchain results returned
           from the collection.
     """
 
@@ -1198,12 +1183,12 @@ class ToolchainCollection:
         self,
         total_count: int,
         limit: int,
-        first: "ToolchainCollectionFirst",
-        last: "ToolchainCollectionLast",
+        first: 'ToolchainCollectionFirst',
+        last: 'ToolchainCollectionLast',
         *,
-        previous: "ToolchainCollectionPrevious" = None,
-        next: "ToolchainCollectionNext" = None,
-        toolchains: List["ToolchainModel"] = None,
+        previous: Optional['ToolchainCollectionPrevious'] = None,
+        next: Optional['ToolchainCollectionNext'] = None,
+        toolchains: Optional[List['ToolchainModel']] = None,
     ) -> None:
         """
         Initialize a ToolchainCollection object.
@@ -1230,31 +1215,31 @@ class ToolchainCollection:
         self.toolchains = toolchains
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainCollection":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainCollection':
         """Initialize a ToolchainCollection object from a json dictionary."""
         args = {}
-        if "total_count" in _dict:
-            args["total_count"] = _dict.get("total_count")
+        if (total_count := _dict.get('total_count')) is not None:
+            args['total_count'] = total_count
         else:
-            raise ValueError("Required property 'total_count' not present in ToolchainCollection JSON")
-        if "limit" in _dict:
-            args["limit"] = _dict.get("limit")
+            raise ValueError('Required property \'total_count\' not present in ToolchainCollection JSON')
+        if (limit := _dict.get('limit')) is not None:
+            args['limit'] = limit
         else:
-            raise ValueError("Required property 'limit' not present in ToolchainCollection JSON")
-        if "first" in _dict:
-            args["first"] = ToolchainCollectionFirst.from_dict(_dict.get("first"))
+            raise ValueError('Required property \'limit\' not present in ToolchainCollection JSON')
+        if (first := _dict.get('first')) is not None:
+            args['first'] = ToolchainCollectionFirst.from_dict(first)
         else:
-            raise ValueError("Required property 'first' not present in ToolchainCollection JSON")
-        if "previous" in _dict:
-            args["previous"] = ToolchainCollectionPrevious.from_dict(_dict.get("previous"))
-        if "next" in _dict:
-            args["next"] = ToolchainCollectionNext.from_dict(_dict.get("next"))
-        if "last" in _dict:
-            args["last"] = ToolchainCollectionLast.from_dict(_dict.get("last"))
+            raise ValueError('Required property \'first\' not present in ToolchainCollection JSON')
+        if (previous := _dict.get('previous')) is not None:
+            args['previous'] = ToolchainCollectionPrevious.from_dict(previous)
+        if (next := _dict.get('next')) is not None:
+            args['next'] = ToolchainCollectionNext.from_dict(next)
+        if (last := _dict.get('last')) is not None:
+            args['last'] = ToolchainCollectionLast.from_dict(last)
         else:
-            raise ValueError("Required property 'last' not present in ToolchainCollection JSON")
-        if "toolchains" in _dict:
-            args["toolchains"] = [ToolchainModel.from_dict(v) for v in _dict.get("toolchains")]
+            raise ValueError('Required property \'last\' not present in ToolchainCollection JSON')
+        if (toolchains := _dict.get('toolchains')) is not None:
+            args['toolchains'] = [ToolchainModel.from_dict(v) for v in toolchains]
         return cls(**args)
 
     @classmethod
@@ -1265,38 +1250,38 @@ class ToolchainCollection:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "total_count") and self.total_count is not None:
-            _dict["total_count"] = self.total_count
-        if hasattr(self, "limit") and self.limit is not None:
-            _dict["limit"] = self.limit
-        if hasattr(self, "first") and self.first is not None:
+        if hasattr(self, 'total_count') and self.total_count is not None:
+            _dict['total_count'] = self.total_count
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'first') and self.first is not None:
             if isinstance(self.first, dict):
-                _dict["first"] = self.first
+                _dict['first'] = self.first
             else:
-                _dict["first"] = self.first.to_dict()
-        if hasattr(self, "previous") and self.previous is not None:
+                _dict['first'] = self.first.to_dict()
+        if hasattr(self, 'previous') and self.previous is not None:
             if isinstance(self.previous, dict):
-                _dict["previous"] = self.previous
+                _dict['previous'] = self.previous
             else:
-                _dict["previous"] = self.previous.to_dict()
-        if hasattr(self, "next") and self.next is not None:
+                _dict['previous'] = self.previous.to_dict()
+        if hasattr(self, 'next') and self.next is not None:
             if isinstance(self.next, dict):
-                _dict["next"] = self.next
+                _dict['next'] = self.next
             else:
-                _dict["next"] = self.next.to_dict()
-        if hasattr(self, "last") and self.last is not None:
+                _dict['next'] = self.next.to_dict()
+        if hasattr(self, 'last') and self.last is not None:
             if isinstance(self.last, dict):
-                _dict["last"] = self.last
+                _dict['last'] = self.last
             else:
-                _dict["last"] = self.last.to_dict()
-        if hasattr(self, "toolchains") and self.toolchains is not None:
+                _dict['last'] = self.last.to_dict()
+        if hasattr(self, 'toolchains') and self.toolchains is not None:
             toolchains_list = []
             for v in self.toolchains:
                 if isinstance(v, dict):
                     toolchains_list.append(v)
                 else:
                     toolchains_list.append(v.to_dict())
-            _dict["toolchains"] = toolchains_list
+            _dict['toolchains'] = toolchains_list
         return _dict
 
     def _to_dict(self):
@@ -1307,13 +1292,13 @@ class ToolchainCollection:
         """Return a `str` version of this ToolchainCollection object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainCollection") -> bool:
+    def __eq__(self, other: 'ToolchainCollection') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainCollection") -> bool:
+    def __ne__(self, other: 'ToolchainCollection') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1322,7 +1307,7 @@ class ToolchainCollectionFirst:
     """
     Information about retrieving first toolchain results from the collection.
 
-    :attr str href: URI that can be used to get first results from the collection.
+    :param str href: URI that can be used to get first results from the collection.
     """
 
     def __init__(
@@ -1338,13 +1323,13 @@ class ToolchainCollectionFirst:
         self.href = href
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainCollectionFirst":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainCollectionFirst':
         """Initialize a ToolchainCollectionFirst object from a json dictionary."""
         args = {}
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainCollectionFirst JSON")
+            raise ValueError('Required property \'href\' not present in ToolchainCollectionFirst JSON')
         return cls(**args)
 
     @classmethod
@@ -1355,8 +1340,8 @@ class ToolchainCollectionFirst:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
         return _dict
 
     def _to_dict(self):
@@ -1367,13 +1352,13 @@ class ToolchainCollectionFirst:
         """Return a `str` version of this ToolchainCollectionFirst object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainCollectionFirst") -> bool:
+    def __eq__(self, other: 'ToolchainCollectionFirst') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainCollectionFirst") -> bool:
+    def __ne__(self, other: 'ToolchainCollectionFirst') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1382,16 +1367,16 @@ class ToolchainCollectionLast:
     """
     Information about retrieving last toolchain results from the collection.
 
-    :attr str start: (optional) Cursor that can be set as the 'start' query
+    :param str start: (optional) Cursor that can be set as the 'start' query
           parameter to get the last set of toolchain collections.
-    :attr str href: URI that can be used to get last results from the collection.
+    :param str href: URI that can be used to get last results from the collection.
     """
 
     def __init__(
         self,
         href: str,
         *,
-        start: str = None,
+        start: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainCollectionLast object.
@@ -1405,15 +1390,15 @@ class ToolchainCollectionLast:
         self.href = href
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainCollectionLast":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainCollectionLast':
         """Initialize a ToolchainCollectionLast object from a json dictionary."""
         args = {}
-        if "start" in _dict:
-            args["start"] = _dict.get("start")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+        if (start := _dict.get('start')) is not None:
+            args['start'] = start
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainCollectionLast JSON")
+            raise ValueError('Required property \'href\' not present in ToolchainCollectionLast JSON')
         return cls(**args)
 
     @classmethod
@@ -1424,10 +1409,10 @@ class ToolchainCollectionLast:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "start") and self.start is not None:
-            _dict["start"] = self.start
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
+        if hasattr(self, 'start') and self.start is not None:
+            _dict['start'] = self.start
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
         return _dict
 
     def _to_dict(self):
@@ -1438,13 +1423,13 @@ class ToolchainCollectionLast:
         """Return a `str` version of this ToolchainCollectionLast object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainCollectionLast") -> bool:
+    def __eq__(self, other: 'ToolchainCollectionLast') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainCollectionLast") -> bool:
+    def __ne__(self, other: 'ToolchainCollectionLast') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1453,16 +1438,16 @@ class ToolchainCollectionNext:
     """
     Information about retrieving next toolchain results from the collection.
 
-    :attr str start: (optional) Cursor that can be set as the 'start' query
+    :param str start: (optional) Cursor that can be set as the 'start' query
           parameter to get the next set of toolchain collections.
-    :attr str href: URI that can be used to get next results from the collection.
+    :param str href: URI that can be used to get next results from the collection.
     """
 
     def __init__(
         self,
         href: str,
         *,
-        start: str = None,
+        start: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainCollectionNext object.
@@ -1476,15 +1461,15 @@ class ToolchainCollectionNext:
         self.href = href
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainCollectionNext":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainCollectionNext':
         """Initialize a ToolchainCollectionNext object from a json dictionary."""
         args = {}
-        if "start" in _dict:
-            args["start"] = _dict.get("start")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+        if (start := _dict.get('start')) is not None:
+            args['start'] = start
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainCollectionNext JSON")
+            raise ValueError('Required property \'href\' not present in ToolchainCollectionNext JSON')
         return cls(**args)
 
     @classmethod
@@ -1495,10 +1480,10 @@ class ToolchainCollectionNext:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "start") and self.start is not None:
-            _dict["start"] = self.start
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
+        if hasattr(self, 'start') and self.start is not None:
+            _dict['start'] = self.start
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
         return _dict
 
     def _to_dict(self):
@@ -1509,13 +1494,13 @@ class ToolchainCollectionNext:
         """Return a `str` version of this ToolchainCollectionNext object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainCollectionNext") -> bool:
+    def __eq__(self, other: 'ToolchainCollectionNext') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainCollectionNext") -> bool:
+    def __ne__(self, other: 'ToolchainCollectionNext') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1524,9 +1509,9 @@ class ToolchainCollectionPrevious:
     """
     Information about retrieving previous toolchain results from the collection.
 
-    :attr str start: (optional) Cursor that can be set as the 'start' query
+    :param str start: (optional) Cursor that can be set as the 'start' query
           parameter to get the previous set of toolchain collections.
-    :attr str href: URI that can be used to get previous results from the
+    :param str href: URI that can be used to get previous results from the
           collection.
     """
 
@@ -1534,7 +1519,7 @@ class ToolchainCollectionPrevious:
         self,
         href: str,
         *,
-        start: str = None,
+        start: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainCollectionPrevious object.
@@ -1548,15 +1533,15 @@ class ToolchainCollectionPrevious:
         self.href = href
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainCollectionPrevious":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainCollectionPrevious':
         """Initialize a ToolchainCollectionPrevious object from a json dictionary."""
         args = {}
-        if "start" in _dict:
-            args["start"] = _dict.get("start")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+        if (start := _dict.get('start')) is not None:
+            args['start'] = start
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainCollectionPrevious JSON")
+            raise ValueError('Required property \'href\' not present in ToolchainCollectionPrevious JSON')
         return cls(**args)
 
     @classmethod
@@ -1567,10 +1552,10 @@ class ToolchainCollectionPrevious:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "start") and self.start is not None:
-            _dict["start"] = self.start
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
+        if hasattr(self, 'start') and self.start is not None:
+            _dict['start'] = self.start
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
         return _dict
 
     def _to_dict(self):
@@ -1581,13 +1566,13 @@ class ToolchainCollectionPrevious:
         """Return a `str` version of this ToolchainCollectionPrevious object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainCollectionPrevious") -> bool:
+    def __eq__(self, other: 'ToolchainCollectionPrevious') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainCollectionPrevious") -> bool:
+    def __ne__(self, other: 'ToolchainCollectionPrevious') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1596,7 +1581,7 @@ class ToolchainEventPost:
     """
     Response structure for POST toolchain event.
 
-    :attr str id: Event ID.
+    :param str id: Event ID.
     """
 
     def __init__(
@@ -1611,13 +1596,13 @@ class ToolchainEventPost:
         self.id = id
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainEventPost":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainEventPost':
         """Initialize a ToolchainEventPost object from a json dictionary."""
         args = {}
-        if "id" in _dict:
-            args["id"] = _dict.get("id")
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
         else:
-            raise ValueError("Required property 'id' not present in ToolchainEventPost JSON")
+            raise ValueError('Required property \'id\' not present in ToolchainEventPost JSON')
         return cls(**args)
 
     @classmethod
@@ -1628,8 +1613,8 @@ class ToolchainEventPost:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "id") and self.id is not None:
-            _dict["id"] = self.id
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
         return _dict
 
     def _to_dict(self):
@@ -1640,13 +1625,13 @@ class ToolchainEventPost:
         """Return a `str` version of this ToolchainEventPost object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainEventPost") -> bool:
+    def __eq__(self, other: 'ToolchainEventPost') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainEventPost") -> bool:
+    def __ne__(self, other: 'ToolchainEventPost') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1656,18 +1641,18 @@ class ToolchainEventPrototypeData:
     Additional data to be added with the event. The format must correspond to the value of
     `content_type`.
 
-    :attr ToolchainEventPrototypeDataApplicationJson application_json: (optional)
+    :param ToolchainEventPrototypeDataApplicationJson application_json: (optional)
           Contains JSON data to be added with the event. `content_type` must be set to
           `application/json`.
-    :attr str text_plain: (optional) Contains text data to be added with the event.
-          `content_type` must be set to `text/plain`.
+    :param ToolchainEventPrototypeDataTextPlain text_plain: (optional) Contains text
+          data to be added with the event. `content_type` must be set to `text/plain`.
     """
 
     def __init__(
         self,
         *,
-        application_json: "ToolchainEventPrototypeDataApplicationJson" = None,
-        text_plain: str = None,
+        application_json: Optional['ToolchainEventPrototypeDataApplicationJson'] = None,
+        text_plain: Optional['ToolchainEventPrototypeDataTextPlain'] = None,
     ) -> None:
         """
         Initialize a ToolchainEventPrototypeData object.
@@ -1675,22 +1660,21 @@ class ToolchainEventPrototypeData:
         :param ToolchainEventPrototypeDataApplicationJson application_json:
                (optional) Contains JSON data to be added with the event. `content_type`
                must be set to `application/json`.
-        :param str text_plain: (optional) Contains text data to be added with the
-               event. `content_type` must be set to `text/plain`.
+        :param ToolchainEventPrototypeDataTextPlain text_plain: (optional) Contains
+               text data to be added with the event. `content_type` must be set to
+               `text/plain`.
         """
         self.application_json = application_json
         self.text_plain = text_plain
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainEventPrototypeData":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainEventPrototypeData':
         """Initialize a ToolchainEventPrototypeData object from a json dictionary."""
         args = {}
-        if "application_json" in _dict:
-            args["application_json"] = ToolchainEventPrototypeDataApplicationJson.from_dict(
-                _dict.get("application_json")
-            )
-        if "text_plain" in _dict:
-            args["text_plain"] = _dict.get("text_plain")
+        if (application_json := _dict.get('application_json')) is not None:
+            args['application_json'] = ToolchainEventPrototypeDataApplicationJson.from_dict(application_json)
+        if (text_plain := _dict.get('text_plain')) is not None:
+            args['text_plain'] = ToolchainEventPrototypeDataTextPlain.from_dict(text_plain)
         return cls(**args)
 
     @classmethod
@@ -1701,13 +1685,16 @@ class ToolchainEventPrototypeData:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "application_json") and self.application_json is not None:
+        if hasattr(self, 'application_json') and self.application_json is not None:
             if isinstance(self.application_json, dict):
-                _dict["application_json"] = self.application_json
+                _dict['application_json'] = self.application_json
             else:
-                _dict["application_json"] = self.application_json.to_dict()
-        if hasattr(self, "text_plain") and self.text_plain is not None:
-            _dict["text_plain"] = self.text_plain
+                _dict['application_json'] = self.application_json.to_dict()
+        if hasattr(self, 'text_plain') and self.text_plain is not None:
+            if isinstance(self.text_plain, dict):
+                _dict['text_plain'] = self.text_plain
+            else:
+                _dict['text_plain'] = self.text_plain.to_dict()
         return _dict
 
     def _to_dict(self):
@@ -1718,13 +1705,13 @@ class ToolchainEventPrototypeData:
         """Return a `str` version of this ToolchainEventPrototypeData object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainEventPrototypeData") -> bool:
+    def __eq__(self, other: 'ToolchainEventPrototypeData') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainEventPrototypeData") -> bool:
+    def __ne__(self, other: 'ToolchainEventPrototypeData') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1734,8 +1721,9 @@ class ToolchainEventPrototypeDataApplicationJson:
     Contains JSON data to be added with the event. `content_type` must be set to
     `application/json`.
 
-    :attr dict content: JSON-formatted key-value pairs representing any additional
-          information to be included with the event.
+    :param dict content: JSON-formatted key-value pairs representing any additional
+          information to be included with the event. The payload is constrained to a
+          maximum depth of 5, and keys that must satisfy the pattern ^[a-zA-Z0-9-_]+$.
     """
 
     def __init__(
@@ -1746,19 +1734,21 @@ class ToolchainEventPrototypeDataApplicationJson:
         Initialize a ToolchainEventPrototypeDataApplicationJson object.
 
         :param dict content: JSON-formatted key-value pairs representing any
-               additional information to be included with the event.
+               additional information to be included with the event. The payload is
+               constrained to a maximum depth of 5, and keys that must satisfy the pattern
+               ^[a-zA-Z0-9-_]+$.
         """
         self.content = content
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainEventPrototypeDataApplicationJson":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainEventPrototypeDataApplicationJson':
         """Initialize a ToolchainEventPrototypeDataApplicationJson object from a json dictionary."""
         args = {}
-        if "content" in _dict:
-            args["content"] = _dict.get("content")
+        if (content := _dict.get('content')) is not None:
+            args['content'] = content
         else:
             raise ValueError(
-                "Required property 'content' not present in ToolchainEventPrototypeDataApplicationJson JSON"
+                'Required property \'content\' not present in ToolchainEventPrototypeDataApplicationJson JSON'
             )
         return cls(**args)
 
@@ -1770,8 +1760,8 @@ class ToolchainEventPrototypeDataApplicationJson:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "content") and self.content is not None:
-            _dict["content"] = self.content
+        if hasattr(self, 'content') and self.content is not None:
+            _dict['content'] = self.content
         return _dict
 
     def _to_dict(self):
@@ -1782,13 +1772,73 @@ class ToolchainEventPrototypeDataApplicationJson:
         """Return a `str` version of this ToolchainEventPrototypeDataApplicationJson object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainEventPrototypeDataApplicationJson") -> bool:
+    def __eq__(self, other: 'ToolchainEventPrototypeDataApplicationJson') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainEventPrototypeDataApplicationJson") -> bool:
+    def __ne__(self, other: 'ToolchainEventPrototypeDataApplicationJson') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class ToolchainEventPrototypeDataTextPlain:
+    """
+    Contains text data to be added with the event. `content_type` must be set to
+    `text/plain`.
+
+    :param str content: The text data to send in the event.
+    """
+
+    def __init__(
+        self,
+        content: str,
+    ) -> None:
+        """
+        Initialize a ToolchainEventPrototypeDataTextPlain object.
+
+        :param str content: The text data to send in the event.
+        """
+        self.content = content
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ToolchainEventPrototypeDataTextPlain':
+        """Initialize a ToolchainEventPrototypeDataTextPlain object from a json dictionary."""
+        args = {}
+        if (content := _dict.get('content')) is not None:
+            args['content'] = content
+        else:
+            raise ValueError('Required property \'content\' not present in ToolchainEventPrototypeDataTextPlain JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ToolchainEventPrototypeDataTextPlain object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'content') and self.content is not None:
+            _dict['content'] = self.content
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ToolchainEventPrototypeDataTextPlain object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ToolchainEventPrototypeDataTextPlain') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ToolchainEventPrototypeDataTextPlain') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1797,18 +1847,18 @@ class ToolchainModel:
     """
     Model describing toolchain resource.
 
-    :attr str id: Toolchain ID.
-    :attr str name: Toolchain name.
-    :attr str description: Describes the toolchain.
-    :attr str account_id: Account ID where toolchain can be found.
-    :attr str location: Toolchain region.
-    :attr str resource_group_id: Resource group where the toolchain is located.
-    :attr str crn: Toolchain CRN.
-    :attr str href: URI that can be used to retrieve toolchain.
-    :attr str ui_href: URL of a user-facing user interface for this toolchain.
-    :attr datetime created_at: Toolchain creation timestamp.
-    :attr datetime updated_at: Latest toolchain update timestamp.
-    :attr str created_by: Identity that created the toolchain.
+    :param str id: Toolchain ID.
+    :param str name: Toolchain name.
+    :param str description: Describes the toolchain.
+    :param str account_id: Account ID where toolchain can be found.
+    :param str location: Toolchain region.
+    :param str resource_group_id: Resource group where the toolchain is located.
+    :param str crn: Toolchain CRN.
+    :param str href: URI that can be used to retrieve toolchain.
+    :param str ui_href: URL of a user-facing user interface for this toolchain.
+    :param datetime created_at: Toolchain creation timestamp.
+    :param datetime updated_at: Latest toolchain update timestamp.
+    :param str created_by: Identity that created the toolchain.
     """
 
     def __init__(
@@ -1857,57 +1907,57 @@ class ToolchainModel:
         self.created_by = created_by
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainModel":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainModel':
         """Initialize a ToolchainModel object from a json dictionary."""
         args = {}
-        if "id" in _dict:
-            args["id"] = _dict.get("id")
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
         else:
-            raise ValueError("Required property 'id' not present in ToolchainModel JSON")
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
+            raise ValueError('Required property \'id\' not present in ToolchainModel JSON')
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
         else:
-            raise ValueError("Required property 'name' not present in ToolchainModel JSON")
-        if "description" in _dict:
-            args["description"] = _dict.get("description")
+            raise ValueError('Required property \'name\' not present in ToolchainModel JSON')
+        if (description := _dict.get('description')) is not None:
+            args['description'] = description
         else:
-            raise ValueError("Required property 'description' not present in ToolchainModel JSON")
-        if "account_id" in _dict:
-            args["account_id"] = _dict.get("account_id")
+            raise ValueError('Required property \'description\' not present in ToolchainModel JSON')
+        if (account_id := _dict.get('account_id')) is not None:
+            args['account_id'] = account_id
         else:
-            raise ValueError("Required property 'account_id' not present in ToolchainModel JSON")
-        if "location" in _dict:
-            args["location"] = _dict.get("location")
+            raise ValueError('Required property \'account_id\' not present in ToolchainModel JSON')
+        if (location := _dict.get('location')) is not None:
+            args['location'] = location
         else:
-            raise ValueError("Required property 'location' not present in ToolchainModel JSON")
-        if "resource_group_id" in _dict:
-            args["resource_group_id"] = _dict.get("resource_group_id")
+            raise ValueError('Required property \'location\' not present in ToolchainModel JSON')
+        if (resource_group_id := _dict.get('resource_group_id')) is not None:
+            args['resource_group_id'] = resource_group_id
         else:
-            raise ValueError("Required property 'resource_group_id' not present in ToolchainModel JSON")
-        if "crn" in _dict:
-            args["crn"] = _dict.get("crn")
+            raise ValueError('Required property \'resource_group_id\' not present in ToolchainModel JSON')
+        if (crn := _dict.get('crn')) is not None:
+            args['crn'] = crn
         else:
-            raise ValueError("Required property 'crn' not present in ToolchainModel JSON")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+            raise ValueError('Required property \'crn\' not present in ToolchainModel JSON')
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainModel JSON")
-        if "ui_href" in _dict:
-            args["ui_href"] = _dict.get("ui_href")
+            raise ValueError('Required property \'href\' not present in ToolchainModel JSON')
+        if (ui_href := _dict.get('ui_href')) is not None:
+            args['ui_href'] = ui_href
         else:
-            raise ValueError("Required property 'ui_href' not present in ToolchainModel JSON")
-        if "created_at" in _dict:
-            args["created_at"] = string_to_datetime(_dict.get("created_at"))
+            raise ValueError('Required property \'ui_href\' not present in ToolchainModel JSON')
+        if (created_at := _dict.get('created_at')) is not None:
+            args['created_at'] = string_to_datetime(created_at)
         else:
-            raise ValueError("Required property 'created_at' not present in ToolchainModel JSON")
-        if "updated_at" in _dict:
-            args["updated_at"] = string_to_datetime(_dict.get("updated_at"))
+            raise ValueError('Required property \'created_at\' not present in ToolchainModel JSON')
+        if (updated_at := _dict.get('updated_at')) is not None:
+            args['updated_at'] = string_to_datetime(updated_at)
         else:
-            raise ValueError("Required property 'updated_at' not present in ToolchainModel JSON")
-        if "created_by" in _dict:
-            args["created_by"] = _dict.get("created_by")
+            raise ValueError('Required property \'updated_at\' not present in ToolchainModel JSON')
+        if (created_by := _dict.get('created_by')) is not None:
+            args['created_by'] = created_by
         else:
-            raise ValueError("Required property 'created_by' not present in ToolchainModel JSON")
+            raise ValueError('Required property \'created_by\' not present in ToolchainModel JSON')
         return cls(**args)
 
     @classmethod
@@ -1918,30 +1968,30 @@ class ToolchainModel:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "id") and self.id is not None:
-            _dict["id"] = self.id
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "description") and self.description is not None:
-            _dict["description"] = self.description
-        if hasattr(self, "account_id") and self.account_id is not None:
-            _dict["account_id"] = self.account_id
-        if hasattr(self, "location") and self.location is not None:
-            _dict["location"] = self.location
-        if hasattr(self, "resource_group_id") and self.resource_group_id is not None:
-            _dict["resource_group_id"] = self.resource_group_id
-        if hasattr(self, "crn") and self.crn is not None:
-            _dict["crn"] = self.crn
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
-        if hasattr(self, "ui_href") and self.ui_href is not None:
-            _dict["ui_href"] = self.ui_href
-        if hasattr(self, "created_at") and self.created_at is not None:
-            _dict["created_at"] = datetime_to_string(self.created_at)
-        if hasattr(self, "updated_at") and self.updated_at is not None:
-            _dict["updated_at"] = datetime_to_string(self.updated_at)
-        if hasattr(self, "created_by") and self.created_by is not None:
-            _dict["created_by"] = self.created_by
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'account_id') and self.account_id is not None:
+            _dict['account_id'] = self.account_id
+        if hasattr(self, 'location') and self.location is not None:
+            _dict['location'] = self.location
+        if hasattr(self, 'resource_group_id') and self.resource_group_id is not None:
+            _dict['resource_group_id'] = self.resource_group_id
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
+        if hasattr(self, 'ui_href') and self.ui_href is not None:
+            _dict['ui_href'] = self.ui_href
+        if hasattr(self, 'created_at') and self.created_at is not None:
+            _dict['created_at'] = datetime_to_string(self.created_at)
+        if hasattr(self, 'updated_at') and self.updated_at is not None:
+            _dict['updated_at'] = datetime_to_string(self.updated_at)
+        if hasattr(self, 'created_by') and self.created_by is not None:
+            _dict['created_by'] = self.created_by
         return _dict
 
     def _to_dict(self):
@@ -1952,13 +2002,13 @@ class ToolchainModel:
         """Return a `str` version of this ToolchainModel object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainModel") -> bool:
+    def __eq__(self, other: 'ToolchainModel') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainModel") -> bool:
+    def __ne__(self, other: 'ToolchainModel') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -1967,18 +2017,18 @@ class ToolchainPatch:
     """
     Response structure for PATCH toolchain.
 
-    :attr str id: Toolchain ID.
-    :attr str name: Toolchain name.
-    :attr str description: Describes the toolchain.
-    :attr str account_id: Account ID where toolchain can be found.
-    :attr str location: Toolchain region.
-    :attr str resource_group_id: Resource group where the toolchain is located.
-    :attr str crn: Toolchain CRN.
-    :attr str href: URI that can be used to retrieve toolchain.
-    :attr str ui_href: URL of a user-facing user interface for this toolchain.
-    :attr datetime created_at: Toolchain creation timestamp.
-    :attr datetime updated_at: Latest toolchain update timestamp.
-    :attr str created_by: Identity that created the toolchain.
+    :param str id: Toolchain ID.
+    :param str name: Toolchain name.
+    :param str description: Describes the toolchain.
+    :param str account_id: Account ID where toolchain can be found.
+    :param str location: Toolchain region.
+    :param str resource_group_id: Resource group where the toolchain is located.
+    :param str crn: Toolchain CRN.
+    :param str href: URI that can be used to retrieve toolchain.
+    :param str ui_href: URL of a user-facing user interface for this toolchain.
+    :param datetime created_at: Toolchain creation timestamp.
+    :param datetime updated_at: Latest toolchain update timestamp.
+    :param str created_by: Identity that created the toolchain.
     """
 
     def __init__(
@@ -2027,57 +2077,57 @@ class ToolchainPatch:
         self.created_by = created_by
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainPatch":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainPatch':
         """Initialize a ToolchainPatch object from a json dictionary."""
         args = {}
-        if "id" in _dict:
-            args["id"] = _dict.get("id")
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
         else:
-            raise ValueError("Required property 'id' not present in ToolchainPatch JSON")
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
+            raise ValueError('Required property \'id\' not present in ToolchainPatch JSON')
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
         else:
-            raise ValueError("Required property 'name' not present in ToolchainPatch JSON")
-        if "description" in _dict:
-            args["description"] = _dict.get("description")
+            raise ValueError('Required property \'name\' not present in ToolchainPatch JSON')
+        if (description := _dict.get('description')) is not None:
+            args['description'] = description
         else:
-            raise ValueError("Required property 'description' not present in ToolchainPatch JSON")
-        if "account_id" in _dict:
-            args["account_id"] = _dict.get("account_id")
+            raise ValueError('Required property \'description\' not present in ToolchainPatch JSON')
+        if (account_id := _dict.get('account_id')) is not None:
+            args['account_id'] = account_id
         else:
-            raise ValueError("Required property 'account_id' not present in ToolchainPatch JSON")
-        if "location" in _dict:
-            args["location"] = _dict.get("location")
+            raise ValueError('Required property \'account_id\' not present in ToolchainPatch JSON')
+        if (location := _dict.get('location')) is not None:
+            args['location'] = location
         else:
-            raise ValueError("Required property 'location' not present in ToolchainPatch JSON")
-        if "resource_group_id" in _dict:
-            args["resource_group_id"] = _dict.get("resource_group_id")
+            raise ValueError('Required property \'location\' not present in ToolchainPatch JSON')
+        if (resource_group_id := _dict.get('resource_group_id')) is not None:
+            args['resource_group_id'] = resource_group_id
         else:
-            raise ValueError("Required property 'resource_group_id' not present in ToolchainPatch JSON")
-        if "crn" in _dict:
-            args["crn"] = _dict.get("crn")
+            raise ValueError('Required property \'resource_group_id\' not present in ToolchainPatch JSON')
+        if (crn := _dict.get('crn')) is not None:
+            args['crn'] = crn
         else:
-            raise ValueError("Required property 'crn' not present in ToolchainPatch JSON")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+            raise ValueError('Required property \'crn\' not present in ToolchainPatch JSON')
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainPatch JSON")
-        if "ui_href" in _dict:
-            args["ui_href"] = _dict.get("ui_href")
+            raise ValueError('Required property \'href\' not present in ToolchainPatch JSON')
+        if (ui_href := _dict.get('ui_href')) is not None:
+            args['ui_href'] = ui_href
         else:
-            raise ValueError("Required property 'ui_href' not present in ToolchainPatch JSON")
-        if "created_at" in _dict:
-            args["created_at"] = string_to_datetime(_dict.get("created_at"))
+            raise ValueError('Required property \'ui_href\' not present in ToolchainPatch JSON')
+        if (created_at := _dict.get('created_at')) is not None:
+            args['created_at'] = string_to_datetime(created_at)
         else:
-            raise ValueError("Required property 'created_at' not present in ToolchainPatch JSON")
-        if "updated_at" in _dict:
-            args["updated_at"] = string_to_datetime(_dict.get("updated_at"))
+            raise ValueError('Required property \'created_at\' not present in ToolchainPatch JSON')
+        if (updated_at := _dict.get('updated_at')) is not None:
+            args['updated_at'] = string_to_datetime(updated_at)
         else:
-            raise ValueError("Required property 'updated_at' not present in ToolchainPatch JSON")
-        if "created_by" in _dict:
-            args["created_by"] = _dict.get("created_by")
+            raise ValueError('Required property \'updated_at\' not present in ToolchainPatch JSON')
+        if (created_by := _dict.get('created_by')) is not None:
+            args['created_by'] = created_by
         else:
-            raise ValueError("Required property 'created_by' not present in ToolchainPatch JSON")
+            raise ValueError('Required property \'created_by\' not present in ToolchainPatch JSON')
         return cls(**args)
 
     @classmethod
@@ -2088,30 +2138,30 @@ class ToolchainPatch:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "id") and self.id is not None:
-            _dict["id"] = self.id
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "description") and self.description is not None:
-            _dict["description"] = self.description
-        if hasattr(self, "account_id") and self.account_id is not None:
-            _dict["account_id"] = self.account_id
-        if hasattr(self, "location") and self.location is not None:
-            _dict["location"] = self.location
-        if hasattr(self, "resource_group_id") and self.resource_group_id is not None:
-            _dict["resource_group_id"] = self.resource_group_id
-        if hasattr(self, "crn") and self.crn is not None:
-            _dict["crn"] = self.crn
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
-        if hasattr(self, "ui_href") and self.ui_href is not None:
-            _dict["ui_href"] = self.ui_href
-        if hasattr(self, "created_at") and self.created_at is not None:
-            _dict["created_at"] = datetime_to_string(self.created_at)
-        if hasattr(self, "updated_at") and self.updated_at is not None:
-            _dict["updated_at"] = datetime_to_string(self.updated_at)
-        if hasattr(self, "created_by") and self.created_by is not None:
-            _dict["created_by"] = self.created_by
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'account_id') and self.account_id is not None:
+            _dict['account_id'] = self.account_id
+        if hasattr(self, 'location') and self.location is not None:
+            _dict['location'] = self.location
+        if hasattr(self, 'resource_group_id') and self.resource_group_id is not None:
+            _dict['resource_group_id'] = self.resource_group_id
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
+        if hasattr(self, 'ui_href') and self.ui_href is not None:
+            _dict['ui_href'] = self.ui_href
+        if hasattr(self, 'created_at') and self.created_at is not None:
+            _dict['created_at'] = datetime_to_string(self.created_at)
+        if hasattr(self, 'updated_at') and self.updated_at is not None:
+            _dict['updated_at'] = datetime_to_string(self.updated_at)
+        if hasattr(self, 'created_by') and self.created_by is not None:
+            _dict['created_by'] = self.created_by
         return _dict
 
     def _to_dict(self):
@@ -2122,13 +2172,13 @@ class ToolchainPatch:
         """Return a `str` version of this ToolchainPatch object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainPatch") -> bool:
+    def __eq__(self, other: 'ToolchainPatch') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainPatch") -> bool:
+    def __ne__(self, other: 'ToolchainPatch') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2137,18 +2187,18 @@ class ToolchainPost:
     """
     Response structure for POST toolchain.
 
-    :attr str id: Toolchain ID.
-    :attr str name: Toolchain name.
-    :attr str description: Describes the toolchain.
-    :attr str account_id: Account ID where toolchain can be found.
-    :attr str location: Toolchain region.
-    :attr str resource_group_id: Resource group where the toolchain is located.
-    :attr str crn: Toolchain CRN.
-    :attr str href: URI that can be used to retrieve toolchain.
-    :attr str ui_href: URL of a user-facing user interface for this toolchain.
-    :attr datetime created_at: Toolchain creation timestamp.
-    :attr datetime updated_at: Latest toolchain update timestamp.
-    :attr str created_by: Identity that created the toolchain.
+    :param str id: Toolchain ID.
+    :param str name: Toolchain name.
+    :param str description: Describes the toolchain.
+    :param str account_id: Account ID where toolchain can be found.
+    :param str location: Toolchain region.
+    :param str resource_group_id: Resource group where the toolchain is located.
+    :param str crn: Toolchain CRN.
+    :param str href: URI that can be used to retrieve toolchain.
+    :param str ui_href: URL of a user-facing user interface for this toolchain.
+    :param datetime created_at: Toolchain creation timestamp.
+    :param datetime updated_at: Latest toolchain update timestamp.
+    :param str created_by: Identity that created the toolchain.
     """
 
     def __init__(
@@ -2197,57 +2247,57 @@ class ToolchainPost:
         self.created_by = created_by
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainPost":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainPost':
         """Initialize a ToolchainPost object from a json dictionary."""
         args = {}
-        if "id" in _dict:
-            args["id"] = _dict.get("id")
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
         else:
-            raise ValueError("Required property 'id' not present in ToolchainPost JSON")
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
+            raise ValueError('Required property \'id\' not present in ToolchainPost JSON')
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
         else:
-            raise ValueError("Required property 'name' not present in ToolchainPost JSON")
-        if "description" in _dict:
-            args["description"] = _dict.get("description")
+            raise ValueError('Required property \'name\' not present in ToolchainPost JSON')
+        if (description := _dict.get('description')) is not None:
+            args['description'] = description
         else:
-            raise ValueError("Required property 'description' not present in ToolchainPost JSON")
-        if "account_id" in _dict:
-            args["account_id"] = _dict.get("account_id")
+            raise ValueError('Required property \'description\' not present in ToolchainPost JSON')
+        if (account_id := _dict.get('account_id')) is not None:
+            args['account_id'] = account_id
         else:
-            raise ValueError("Required property 'account_id' not present in ToolchainPost JSON")
-        if "location" in _dict:
-            args["location"] = _dict.get("location")
+            raise ValueError('Required property \'account_id\' not present in ToolchainPost JSON')
+        if (location := _dict.get('location')) is not None:
+            args['location'] = location
         else:
-            raise ValueError("Required property 'location' not present in ToolchainPost JSON")
-        if "resource_group_id" in _dict:
-            args["resource_group_id"] = _dict.get("resource_group_id")
+            raise ValueError('Required property \'location\' not present in ToolchainPost JSON')
+        if (resource_group_id := _dict.get('resource_group_id')) is not None:
+            args['resource_group_id'] = resource_group_id
         else:
-            raise ValueError("Required property 'resource_group_id' not present in ToolchainPost JSON")
-        if "crn" in _dict:
-            args["crn"] = _dict.get("crn")
+            raise ValueError('Required property \'resource_group_id\' not present in ToolchainPost JSON')
+        if (crn := _dict.get('crn')) is not None:
+            args['crn'] = crn
         else:
-            raise ValueError("Required property 'crn' not present in ToolchainPost JSON")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+            raise ValueError('Required property \'crn\' not present in ToolchainPost JSON')
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainPost JSON")
-        if "ui_href" in _dict:
-            args["ui_href"] = _dict.get("ui_href")
+            raise ValueError('Required property \'href\' not present in ToolchainPost JSON')
+        if (ui_href := _dict.get('ui_href')) is not None:
+            args['ui_href'] = ui_href
         else:
-            raise ValueError("Required property 'ui_href' not present in ToolchainPost JSON")
-        if "created_at" in _dict:
-            args["created_at"] = string_to_datetime(_dict.get("created_at"))
+            raise ValueError('Required property \'ui_href\' not present in ToolchainPost JSON')
+        if (created_at := _dict.get('created_at')) is not None:
+            args['created_at'] = string_to_datetime(created_at)
         else:
-            raise ValueError("Required property 'created_at' not present in ToolchainPost JSON")
-        if "updated_at" in _dict:
-            args["updated_at"] = string_to_datetime(_dict.get("updated_at"))
+            raise ValueError('Required property \'created_at\' not present in ToolchainPost JSON')
+        if (updated_at := _dict.get('updated_at')) is not None:
+            args['updated_at'] = string_to_datetime(updated_at)
         else:
-            raise ValueError("Required property 'updated_at' not present in ToolchainPost JSON")
-        if "created_by" in _dict:
-            args["created_by"] = _dict.get("created_by")
+            raise ValueError('Required property \'updated_at\' not present in ToolchainPost JSON')
+        if (created_by := _dict.get('created_by')) is not None:
+            args['created_by'] = created_by
         else:
-            raise ValueError("Required property 'created_by' not present in ToolchainPost JSON")
+            raise ValueError('Required property \'created_by\' not present in ToolchainPost JSON')
         return cls(**args)
 
     @classmethod
@@ -2258,30 +2308,30 @@ class ToolchainPost:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "id") and self.id is not None:
-            _dict["id"] = self.id
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "description") and self.description is not None:
-            _dict["description"] = self.description
-        if hasattr(self, "account_id") and self.account_id is not None:
-            _dict["account_id"] = self.account_id
-        if hasattr(self, "location") and self.location is not None:
-            _dict["location"] = self.location
-        if hasattr(self, "resource_group_id") and self.resource_group_id is not None:
-            _dict["resource_group_id"] = self.resource_group_id
-        if hasattr(self, "crn") and self.crn is not None:
-            _dict["crn"] = self.crn
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
-        if hasattr(self, "ui_href") and self.ui_href is not None:
-            _dict["ui_href"] = self.ui_href
-        if hasattr(self, "created_at") and self.created_at is not None:
-            _dict["created_at"] = datetime_to_string(self.created_at)
-        if hasattr(self, "updated_at") and self.updated_at is not None:
-            _dict["updated_at"] = datetime_to_string(self.updated_at)
-        if hasattr(self, "created_by") and self.created_by is not None:
-            _dict["created_by"] = self.created_by
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'account_id') and self.account_id is not None:
+            _dict['account_id'] = self.account_id
+        if hasattr(self, 'location') and self.location is not None:
+            _dict['location'] = self.location
+        if hasattr(self, 'resource_group_id') and self.resource_group_id is not None:
+            _dict['resource_group_id'] = self.resource_group_id
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
+        if hasattr(self, 'ui_href') and self.ui_href is not None:
+            _dict['ui_href'] = self.ui_href
+        if hasattr(self, 'created_at') and self.created_at is not None:
+            _dict['created_at'] = datetime_to_string(self.created_at)
+        if hasattr(self, 'updated_at') and self.updated_at is not None:
+            _dict['updated_at'] = datetime_to_string(self.updated_at)
+        if hasattr(self, 'created_by') and self.created_by is not None:
+            _dict['created_by'] = self.created_by
         return _dict
 
     def _to_dict(self):
@@ -2292,13 +2342,13 @@ class ToolchainPost:
         """Return a `str` version of this ToolchainPost object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainPost") -> bool:
+    def __eq__(self, other: 'ToolchainPost') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainPost") -> bool:
+    def __ne__(self, other: 'ToolchainPost') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2307,15 +2357,15 @@ class ToolchainPrototypePatch:
     """
     Body structure for the update toolchain PATCH request.
 
-    :attr str name: (optional) The name of the toolchain.
-    :attr str description: (optional) An optional description.
+    :param str name: (optional) The name of the toolchain.
+    :param str description: (optional) An optional description.
     """
 
     def __init__(
         self,
         *,
-        name: str = None,
-        description: str = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainPrototypePatch object.
@@ -2327,13 +2377,13 @@ class ToolchainPrototypePatch:
         self.description = description
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainPrototypePatch":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainPrototypePatch':
         """Initialize a ToolchainPrototypePatch object from a json dictionary."""
         args = {}
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
-        if "description" in _dict:
-            args["description"] = _dict.get("description")
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
+        if (description := _dict.get('description')) is not None:
+            args['description'] = description
         return cls(**args)
 
     @classmethod
@@ -2344,10 +2394,10 @@ class ToolchainPrototypePatch:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "description") and self.description is not None:
-            _dict["description"] = self.description
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
         return _dict
 
     def _to_dict(self):
@@ -2358,13 +2408,13 @@ class ToolchainPrototypePatch:
         """Return a `str` version of this ToolchainPrototypePatch object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainPrototypePatch") -> bool:
+    def __eq__(self, other: 'ToolchainPrototypePatch') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainPrototypePatch") -> bool:
+    def __ne__(self, other: 'ToolchainPrototypePatch') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2373,27 +2423,27 @@ class ToolchainTool:
     """
     Response structure for GET tool.
 
-    :attr str id: Tool ID.
-    :attr str resource_group_id: Resource group where the tool is located.
-    :attr str crn: Tool CRN.
-    :attr str tool_type_id: The unique name of the provisioned tool. A table of
+    :param str id: Tool ID.
+    :param str resource_group_id: Resource group where the tool is located.
+    :param str crn: Tool CRN.
+    :param str tool_type_id: The unique name of the provisioned tool. A table of
           `tool_type_id` values corresponding to each tool integration can be found in the
           <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
-    :attr str toolchain_id: ID of toolchain which the tool is bound to.
-    :attr str toolchain_crn: CRN of toolchain which the tool is bound to.
-    :attr str href: URI representing the tool.
-    :attr ToolModelReferent referent: Information on URIs to access this resource
+    :param str toolchain_id: ID of toolchain which the tool is bound to.
+    :param str toolchain_crn: CRN of toolchain which the tool is bound to.
+    :param str href: URI representing the tool.
+    :param ToolModelReferent referent: Information on URIs to access this resource
           through the UI or API.
-    :attr str name: (optional) Name of the tool.
-    :attr datetime updated_at: Latest tool update timestamp.
-    :attr dict parameters: Unique key-value pairs representing parameters to be used
-          to create the tool. A list of parameters for each tool integration can be found
-          in the <a
+    :param str name: (optional) Name of the tool.
+    :param datetime updated_at: Latest tool update timestamp.
+    :param dict parameters: Unique key-value pairs representing parameters to be
+          used to create the tool. A list of parameters for each tool integration can be
+          found in the <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
-    :attr str state: Current configuration state of the tool.
+    :param str state: Current configuration state of the tool.
     """
 
     def __init__(
@@ -2405,12 +2455,12 @@ class ToolchainTool:
         toolchain_id: str,
         toolchain_crn: str,
         href: str,
-        referent: "ToolModelReferent",
+        referent: 'ToolModelReferent',
         updated_at: datetime,
         parameters: dict,
         state: str,
         *,
-        name: str = None,
+        name: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainTool object.
@@ -2451,55 +2501,55 @@ class ToolchainTool:
         self.state = state
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainTool":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainTool':
         """Initialize a ToolchainTool object from a json dictionary."""
         args = {}
-        if "id" in _dict:
-            args["id"] = _dict.get("id")
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
         else:
-            raise ValueError("Required property 'id' not present in ToolchainTool JSON")
-        if "resource_group_id" in _dict:
-            args["resource_group_id"] = _dict.get("resource_group_id")
+            raise ValueError('Required property \'id\' not present in ToolchainTool JSON')
+        if (resource_group_id := _dict.get('resource_group_id')) is not None:
+            args['resource_group_id'] = resource_group_id
         else:
-            raise ValueError("Required property 'resource_group_id' not present in ToolchainTool JSON")
-        if "crn" in _dict:
-            args["crn"] = _dict.get("crn")
+            raise ValueError('Required property \'resource_group_id\' not present in ToolchainTool JSON')
+        if (crn := _dict.get('crn')) is not None:
+            args['crn'] = crn
         else:
-            raise ValueError("Required property 'crn' not present in ToolchainTool JSON")
-        if "tool_type_id" in _dict:
-            args["tool_type_id"] = _dict.get("tool_type_id")
+            raise ValueError('Required property \'crn\' not present in ToolchainTool JSON')
+        if (tool_type_id := _dict.get('tool_type_id')) is not None:
+            args['tool_type_id'] = tool_type_id
         else:
-            raise ValueError("Required property 'tool_type_id' not present in ToolchainTool JSON")
-        if "toolchain_id" in _dict:
-            args["toolchain_id"] = _dict.get("toolchain_id")
+            raise ValueError('Required property \'tool_type_id\' not present in ToolchainTool JSON')
+        if (toolchain_id := _dict.get('toolchain_id')) is not None:
+            args['toolchain_id'] = toolchain_id
         else:
-            raise ValueError("Required property 'toolchain_id' not present in ToolchainTool JSON")
-        if "toolchain_crn" in _dict:
-            args["toolchain_crn"] = _dict.get("toolchain_crn")
+            raise ValueError('Required property \'toolchain_id\' not present in ToolchainTool JSON')
+        if (toolchain_crn := _dict.get('toolchain_crn')) is not None:
+            args['toolchain_crn'] = toolchain_crn
         else:
-            raise ValueError("Required property 'toolchain_crn' not present in ToolchainTool JSON")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+            raise ValueError('Required property \'toolchain_crn\' not present in ToolchainTool JSON')
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainTool JSON")
-        if "referent" in _dict:
-            args["referent"] = ToolModelReferent.from_dict(_dict.get("referent"))
+            raise ValueError('Required property \'href\' not present in ToolchainTool JSON')
+        if (referent := _dict.get('referent')) is not None:
+            args['referent'] = ToolModelReferent.from_dict(referent)
         else:
-            raise ValueError("Required property 'referent' not present in ToolchainTool JSON")
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
-        if "updated_at" in _dict:
-            args["updated_at"] = string_to_datetime(_dict.get("updated_at"))
+            raise ValueError('Required property \'referent\' not present in ToolchainTool JSON')
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
+        if (updated_at := _dict.get('updated_at')) is not None:
+            args['updated_at'] = string_to_datetime(updated_at)
         else:
-            raise ValueError("Required property 'updated_at' not present in ToolchainTool JSON")
-        if "parameters" in _dict:
-            args["parameters"] = _dict.get("parameters")
+            raise ValueError('Required property \'updated_at\' not present in ToolchainTool JSON')
+        if (parameters := _dict.get('parameters')) is not None:
+            args['parameters'] = parameters
         else:
-            raise ValueError("Required property 'parameters' not present in ToolchainTool JSON")
-        if "state" in _dict:
-            args["state"] = _dict.get("state")
+            raise ValueError('Required property \'parameters\' not present in ToolchainTool JSON')
+        if (state := _dict.get('state')) is not None:
+            args['state'] = state
         else:
-            raise ValueError("Required property 'state' not present in ToolchainTool JSON")
+            raise ValueError('Required property \'state\' not present in ToolchainTool JSON')
         return cls(**args)
 
     @classmethod
@@ -2510,33 +2560,33 @@ class ToolchainTool:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "id") and self.id is not None:
-            _dict["id"] = self.id
-        if hasattr(self, "resource_group_id") and self.resource_group_id is not None:
-            _dict["resource_group_id"] = self.resource_group_id
-        if hasattr(self, "crn") and self.crn is not None:
-            _dict["crn"] = self.crn
-        if hasattr(self, "tool_type_id") and self.tool_type_id is not None:
-            _dict["tool_type_id"] = self.tool_type_id
-        if hasattr(self, "toolchain_id") and self.toolchain_id is not None:
-            _dict["toolchain_id"] = self.toolchain_id
-        if hasattr(self, "toolchain_crn") and self.toolchain_crn is not None:
-            _dict["toolchain_crn"] = self.toolchain_crn
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
-        if hasattr(self, "referent") and self.referent is not None:
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'resource_group_id') and self.resource_group_id is not None:
+            _dict['resource_group_id'] = self.resource_group_id
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'tool_type_id') and self.tool_type_id is not None:
+            _dict['tool_type_id'] = self.tool_type_id
+        if hasattr(self, 'toolchain_id') and self.toolchain_id is not None:
+            _dict['toolchain_id'] = self.toolchain_id
+        if hasattr(self, 'toolchain_crn') and self.toolchain_crn is not None:
+            _dict['toolchain_crn'] = self.toolchain_crn
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
+        if hasattr(self, 'referent') and self.referent is not None:
             if isinstance(self.referent, dict):
-                _dict["referent"] = self.referent
+                _dict['referent'] = self.referent
             else:
-                _dict["referent"] = self.referent.to_dict()
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "updated_at") and self.updated_at is not None:
-            _dict["updated_at"] = datetime_to_string(self.updated_at)
-        if hasattr(self, "parameters") and self.parameters is not None:
-            _dict["parameters"] = self.parameters
-        if hasattr(self, "state") and self.state is not None:
-            _dict["state"] = self.state
+                _dict['referent'] = self.referent.to_dict()
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'updated_at') and self.updated_at is not None:
+            _dict['updated_at'] = datetime_to_string(self.updated_at)
+        if hasattr(self, 'parameters') and self.parameters is not None:
+            _dict['parameters'] = self.parameters
+        if hasattr(self, 'state') and self.state is not None:
+            _dict['state'] = self.state
         return _dict
 
     def _to_dict(self):
@@ -2547,13 +2597,13 @@ class ToolchainTool:
         """Return a `str` version of this ToolchainTool object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainTool") -> bool:
+    def __eq__(self, other: 'ToolchainTool') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainTool") -> bool:
+    def __ne__(self, other: 'ToolchainTool') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2562,39 +2612,39 @@ class ToolchainTool:
         Current configuration state of the tool.
         """
 
-        CONFIGURED = "configured"
-        CONFIGURING = "configuring"
-        MISCONFIGURED = "misconfigured"
-        UNCONFIGURED = "unconfigured"
+        CONFIGURED = 'configured'
+        CONFIGURING = 'configuring'
+        MISCONFIGURED = 'misconfigured'
+        UNCONFIGURED = 'unconfigured'
 
 
 class ToolchainToolCollection:
     """
     Response structure for GET tools.
 
-    :attr int limit: Maximum number of tools returned from collection.
-    :attr int total_count: Total number of tools found in collection.
-    :attr ToolchainToolCollectionFirst first: Information about retrieving first
+    :param int limit: Maximum number of tools returned from collection.
+    :param int total_count: Total number of tools found in collection.
+    :param ToolchainToolCollectionFirst first: Information about retrieving first
           tool results from the collection.
-    :attr ToolchainToolCollectionPrevious previous: (optional) Information about
+    :param ToolchainToolCollectionPrevious previous: (optional) Information about
           retrieving previous tool results from the collection.
-    :attr ToolchainToolCollectionNext next: (optional) Information about retrieving
+    :param ToolchainToolCollectionNext next: (optional) Information about retrieving
           next tool results from the collection.
-    :attr ToolchainToolCollectionLast last: Information about retrieving last tool
+    :param ToolchainToolCollectionLast last: Information about retrieving last tool
           results from the collection.
-    :attr List[ToolModel] tools: Tool results returned from the collection.
+    :param List[ToolModel] tools: Tool results returned from the collection.
     """
 
     def __init__(
         self,
         limit: int,
         total_count: int,
-        first: "ToolchainToolCollectionFirst",
-        last: "ToolchainToolCollectionLast",
-        tools: List["ToolModel"],
+        first: 'ToolchainToolCollectionFirst',
+        last: 'ToolchainToolCollectionLast',
+        tools: List['ToolModel'],
         *,
-        previous: "ToolchainToolCollectionPrevious" = None,
-        next: "ToolchainToolCollectionNext" = None,
+        previous: Optional['ToolchainToolCollectionPrevious'] = None,
+        next: Optional['ToolchainToolCollectionNext'] = None,
     ) -> None:
         """
         Initialize a ToolchainToolCollection object.
@@ -2620,33 +2670,33 @@ class ToolchainToolCollection:
         self.tools = tools
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainToolCollection":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainToolCollection':
         """Initialize a ToolchainToolCollection object from a json dictionary."""
         args = {}
-        if "limit" in _dict:
-            args["limit"] = _dict.get("limit")
+        if (limit := _dict.get('limit')) is not None:
+            args['limit'] = limit
         else:
-            raise ValueError("Required property 'limit' not present in ToolchainToolCollection JSON")
-        if "total_count" in _dict:
-            args["total_count"] = _dict.get("total_count")
+            raise ValueError('Required property \'limit\' not present in ToolchainToolCollection JSON')
+        if (total_count := _dict.get('total_count')) is not None:
+            args['total_count'] = total_count
         else:
-            raise ValueError("Required property 'total_count' not present in ToolchainToolCollection JSON")
-        if "first" in _dict:
-            args["first"] = ToolchainToolCollectionFirst.from_dict(_dict.get("first"))
+            raise ValueError('Required property \'total_count\' not present in ToolchainToolCollection JSON')
+        if (first := _dict.get('first')) is not None:
+            args['first'] = ToolchainToolCollectionFirst.from_dict(first)
         else:
-            raise ValueError("Required property 'first' not present in ToolchainToolCollection JSON")
-        if "previous" in _dict:
-            args["previous"] = ToolchainToolCollectionPrevious.from_dict(_dict.get("previous"))
-        if "next" in _dict:
-            args["next"] = ToolchainToolCollectionNext.from_dict(_dict.get("next"))
-        if "last" in _dict:
-            args["last"] = ToolchainToolCollectionLast.from_dict(_dict.get("last"))
+            raise ValueError('Required property \'first\' not present in ToolchainToolCollection JSON')
+        if (previous := _dict.get('previous')) is not None:
+            args['previous'] = ToolchainToolCollectionPrevious.from_dict(previous)
+        if (next := _dict.get('next')) is not None:
+            args['next'] = ToolchainToolCollectionNext.from_dict(next)
+        if (last := _dict.get('last')) is not None:
+            args['last'] = ToolchainToolCollectionLast.from_dict(last)
         else:
-            raise ValueError("Required property 'last' not present in ToolchainToolCollection JSON")
-        if "tools" in _dict:
-            args["tools"] = [ToolModel.from_dict(v) for v in _dict.get("tools")]
+            raise ValueError('Required property \'last\' not present in ToolchainToolCollection JSON')
+        if (tools := _dict.get('tools')) is not None:
+            args['tools'] = [ToolModel.from_dict(v) for v in tools]
         else:
-            raise ValueError("Required property 'tools' not present in ToolchainToolCollection JSON")
+            raise ValueError('Required property \'tools\' not present in ToolchainToolCollection JSON')
         return cls(**args)
 
     @classmethod
@@ -2657,38 +2707,38 @@ class ToolchainToolCollection:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "limit") and self.limit is not None:
-            _dict["limit"] = self.limit
-        if hasattr(self, "total_count") and self.total_count is not None:
-            _dict["total_count"] = self.total_count
-        if hasattr(self, "first") and self.first is not None:
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'total_count') and self.total_count is not None:
+            _dict['total_count'] = self.total_count
+        if hasattr(self, 'first') and self.first is not None:
             if isinstance(self.first, dict):
-                _dict["first"] = self.first
+                _dict['first'] = self.first
             else:
-                _dict["first"] = self.first.to_dict()
-        if hasattr(self, "previous") and self.previous is not None:
+                _dict['first'] = self.first.to_dict()
+        if hasattr(self, 'previous') and self.previous is not None:
             if isinstance(self.previous, dict):
-                _dict["previous"] = self.previous
+                _dict['previous'] = self.previous
             else:
-                _dict["previous"] = self.previous.to_dict()
-        if hasattr(self, "next") and self.next is not None:
+                _dict['previous'] = self.previous.to_dict()
+        if hasattr(self, 'next') and self.next is not None:
             if isinstance(self.next, dict):
-                _dict["next"] = self.next
+                _dict['next'] = self.next
             else:
-                _dict["next"] = self.next.to_dict()
-        if hasattr(self, "last") and self.last is not None:
+                _dict['next'] = self.next.to_dict()
+        if hasattr(self, 'last') and self.last is not None:
             if isinstance(self.last, dict):
-                _dict["last"] = self.last
+                _dict['last'] = self.last
             else:
-                _dict["last"] = self.last.to_dict()
-        if hasattr(self, "tools") and self.tools is not None:
+                _dict['last'] = self.last.to_dict()
+        if hasattr(self, 'tools') and self.tools is not None:
             tools_list = []
             for v in self.tools:
                 if isinstance(v, dict):
                     tools_list.append(v)
                 else:
                     tools_list.append(v.to_dict())
-            _dict["tools"] = tools_list
+            _dict['tools'] = tools_list
         return _dict
 
     def _to_dict(self):
@@ -2699,13 +2749,13 @@ class ToolchainToolCollection:
         """Return a `str` version of this ToolchainToolCollection object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainToolCollection") -> bool:
+    def __eq__(self, other: 'ToolchainToolCollection') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainToolCollection") -> bool:
+    def __ne__(self, other: 'ToolchainToolCollection') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2714,7 +2764,7 @@ class ToolchainToolCollectionFirst:
     """
     Information about retrieving first tool results from the collection.
 
-    :attr str href: URI that can be used to get first results from the collection.
+    :param str href: URI that can be used to get first results from the collection.
     """
 
     def __init__(
@@ -2730,13 +2780,13 @@ class ToolchainToolCollectionFirst:
         self.href = href
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainToolCollectionFirst":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainToolCollectionFirst':
         """Initialize a ToolchainToolCollectionFirst object from a json dictionary."""
         args = {}
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainToolCollectionFirst JSON")
+            raise ValueError('Required property \'href\' not present in ToolchainToolCollectionFirst JSON')
         return cls(**args)
 
     @classmethod
@@ -2747,8 +2797,8 @@ class ToolchainToolCollectionFirst:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
         return _dict
 
     def _to_dict(self):
@@ -2759,13 +2809,13 @@ class ToolchainToolCollectionFirst:
         """Return a `str` version of this ToolchainToolCollectionFirst object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainToolCollectionFirst") -> bool:
+    def __eq__(self, other: 'ToolchainToolCollectionFirst') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainToolCollectionFirst") -> bool:
+    def __ne__(self, other: 'ToolchainToolCollectionFirst') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2774,16 +2824,16 @@ class ToolchainToolCollectionLast:
     """
     Information about retrieving last tool results from the collection.
 
-    :attr str start: (optional) Cursor that can be used to get the last set of tool
+    :param str start: (optional) Cursor that can be used to get the last set of tool
           collections.
-    :attr str href: URI that can be used to get last results from the collection.
+    :param str href: URI that can be used to get last results from the collection.
     """
 
     def __init__(
         self,
         href: str,
         *,
-        start: str = None,
+        start: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainToolCollectionLast object.
@@ -2797,15 +2847,15 @@ class ToolchainToolCollectionLast:
         self.href = href
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainToolCollectionLast":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainToolCollectionLast':
         """Initialize a ToolchainToolCollectionLast object from a json dictionary."""
         args = {}
-        if "start" in _dict:
-            args["start"] = _dict.get("start")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+        if (start := _dict.get('start')) is not None:
+            args['start'] = start
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainToolCollectionLast JSON")
+            raise ValueError('Required property \'href\' not present in ToolchainToolCollectionLast JSON')
         return cls(**args)
 
     @classmethod
@@ -2816,10 +2866,10 @@ class ToolchainToolCollectionLast:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "start") and self.start is not None:
-            _dict["start"] = self.start
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
+        if hasattr(self, 'start') and self.start is not None:
+            _dict['start'] = self.start
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
         return _dict
 
     def _to_dict(self):
@@ -2830,13 +2880,13 @@ class ToolchainToolCollectionLast:
         """Return a `str` version of this ToolchainToolCollectionLast object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainToolCollectionLast") -> bool:
+    def __eq__(self, other: 'ToolchainToolCollectionLast') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainToolCollectionLast") -> bool:
+    def __ne__(self, other: 'ToolchainToolCollectionLast') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2845,16 +2895,16 @@ class ToolchainToolCollectionNext:
     """
     Information about retrieving next tool results from the collection.
 
-    :attr str start: (optional) Cursor that can be used to get the next set of tool
+    :param str start: (optional) Cursor that can be used to get the next set of tool
           collections.
-    :attr str href: URI that can be used to get next results from the collection.
+    :param str href: URI that can be used to get next results from the collection.
     """
 
     def __init__(
         self,
         href: str,
         *,
-        start: str = None,
+        start: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainToolCollectionNext object.
@@ -2868,15 +2918,15 @@ class ToolchainToolCollectionNext:
         self.href = href
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainToolCollectionNext":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainToolCollectionNext':
         """Initialize a ToolchainToolCollectionNext object from a json dictionary."""
         args = {}
-        if "start" in _dict:
-            args["start"] = _dict.get("start")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+        if (start := _dict.get('start')) is not None:
+            args['start'] = start
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainToolCollectionNext JSON")
+            raise ValueError('Required property \'href\' not present in ToolchainToolCollectionNext JSON')
         return cls(**args)
 
     @classmethod
@@ -2887,10 +2937,10 @@ class ToolchainToolCollectionNext:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "start") and self.start is not None:
-            _dict["start"] = self.start
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
+        if hasattr(self, 'start') and self.start is not None:
+            _dict['start'] = self.start
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
         return _dict
 
     def _to_dict(self):
@@ -2901,13 +2951,13 @@ class ToolchainToolCollectionNext:
         """Return a `str` version of this ToolchainToolCollectionNext object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainToolCollectionNext") -> bool:
+    def __eq__(self, other: 'ToolchainToolCollectionNext') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainToolCollectionNext") -> bool:
+    def __ne__(self, other: 'ToolchainToolCollectionNext') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2916,9 +2966,9 @@ class ToolchainToolCollectionPrevious:
     """
     Information about retrieving previous tool results from the collection.
 
-    :attr str start: (optional) Cursor that can be used to get the previous set of
+    :param str start: (optional) Cursor that can be used to get the previous set of
           tool collections.
-    :attr str href: URI that can be used to get previous results from the
+    :param str href: URI that can be used to get previous results from the
           collection.
     """
 
@@ -2926,7 +2976,7 @@ class ToolchainToolCollectionPrevious:
         self,
         href: str,
         *,
-        start: str = None,
+        start: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainToolCollectionPrevious object.
@@ -2940,15 +2990,15 @@ class ToolchainToolCollectionPrevious:
         self.href = href
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainToolCollectionPrevious":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainToolCollectionPrevious':
         """Initialize a ToolchainToolCollectionPrevious object from a json dictionary."""
         args = {}
-        if "start" in _dict:
-            args["start"] = _dict.get("start")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+        if (start := _dict.get('start')) is not None:
+            args['start'] = start
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainToolCollectionPrevious JSON")
+            raise ValueError('Required property \'href\' not present in ToolchainToolCollectionPrevious JSON')
         return cls(**args)
 
     @classmethod
@@ -2959,10 +3009,10 @@ class ToolchainToolCollectionPrevious:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "start") and self.start is not None:
-            _dict["start"] = self.start
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
+        if hasattr(self, 'start') and self.start is not None:
+            _dict['start'] = self.start
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
         return _dict
 
     def _to_dict(self):
@@ -2973,13 +3023,13 @@ class ToolchainToolCollectionPrevious:
         """Return a `str` version of this ToolchainToolCollectionPrevious object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainToolCollectionPrevious") -> bool:
+    def __eq__(self, other: 'ToolchainToolCollectionPrevious') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainToolCollectionPrevious") -> bool:
+    def __ne__(self, other: 'ToolchainToolCollectionPrevious') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2988,27 +3038,27 @@ class ToolchainToolPatch:
     """
     Response structure for PATCH tool.
 
-    :attr str id: Tool ID.
-    :attr str resource_group_id: Resource group where the tool is located.
-    :attr str crn: Tool CRN.
-    :attr str tool_type_id: The unique name of the provisioned tool. A table of
+    :param str id: Tool ID.
+    :param str resource_group_id: Resource group where the tool is located.
+    :param str crn: Tool CRN.
+    :param str tool_type_id: The unique name of the provisioned tool. A table of
           `tool_type_id` values corresponding to each tool integration can be found in the
           <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
-    :attr str toolchain_id: ID of toolchain which the tool is bound to.
-    :attr str toolchain_crn: CRN of toolchain which the tool is bound to.
-    :attr str href: URI representing the tool.
-    :attr ToolModelReferent referent: Information on URIs to access this resource
+    :param str toolchain_id: ID of toolchain which the tool is bound to.
+    :param str toolchain_crn: CRN of toolchain which the tool is bound to.
+    :param str href: URI representing the tool.
+    :param ToolModelReferent referent: Information on URIs to access this resource
           through the UI or API.
-    :attr str name: (optional) Name of the tool.
-    :attr datetime updated_at: Latest tool update timestamp.
-    :attr dict parameters: Unique key-value pairs representing parameters to be used
-          to create the tool. A list of parameters for each tool integration can be found
-          in the <a
+    :param str name: (optional) Name of the tool.
+    :param datetime updated_at: Latest tool update timestamp.
+    :param dict parameters: Unique key-value pairs representing parameters to be
+          used to create the tool. A list of parameters for each tool integration can be
+          found in the <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
-    :attr str state: Current configuration state of the tool.
+    :param str state: Current configuration state of the tool.
     """
 
     def __init__(
@@ -3020,12 +3070,12 @@ class ToolchainToolPatch:
         toolchain_id: str,
         toolchain_crn: str,
         href: str,
-        referent: "ToolModelReferent",
+        referent: 'ToolModelReferent',
         updated_at: datetime,
         parameters: dict,
         state: str,
         *,
-        name: str = None,
+        name: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainToolPatch object.
@@ -3066,55 +3116,55 @@ class ToolchainToolPatch:
         self.state = state
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainToolPatch":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainToolPatch':
         """Initialize a ToolchainToolPatch object from a json dictionary."""
         args = {}
-        if "id" in _dict:
-            args["id"] = _dict.get("id")
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
         else:
-            raise ValueError("Required property 'id' not present in ToolchainToolPatch JSON")
-        if "resource_group_id" in _dict:
-            args["resource_group_id"] = _dict.get("resource_group_id")
+            raise ValueError('Required property \'id\' not present in ToolchainToolPatch JSON')
+        if (resource_group_id := _dict.get('resource_group_id')) is not None:
+            args['resource_group_id'] = resource_group_id
         else:
-            raise ValueError("Required property 'resource_group_id' not present in ToolchainToolPatch JSON")
-        if "crn" in _dict:
-            args["crn"] = _dict.get("crn")
+            raise ValueError('Required property \'resource_group_id\' not present in ToolchainToolPatch JSON')
+        if (crn := _dict.get('crn')) is not None:
+            args['crn'] = crn
         else:
-            raise ValueError("Required property 'crn' not present in ToolchainToolPatch JSON")
-        if "tool_type_id" in _dict:
-            args["tool_type_id"] = _dict.get("tool_type_id")
+            raise ValueError('Required property \'crn\' not present in ToolchainToolPatch JSON')
+        if (tool_type_id := _dict.get('tool_type_id')) is not None:
+            args['tool_type_id'] = tool_type_id
         else:
-            raise ValueError("Required property 'tool_type_id' not present in ToolchainToolPatch JSON")
-        if "toolchain_id" in _dict:
-            args["toolchain_id"] = _dict.get("toolchain_id")
+            raise ValueError('Required property \'tool_type_id\' not present in ToolchainToolPatch JSON')
+        if (toolchain_id := _dict.get('toolchain_id')) is not None:
+            args['toolchain_id'] = toolchain_id
         else:
-            raise ValueError("Required property 'toolchain_id' not present in ToolchainToolPatch JSON")
-        if "toolchain_crn" in _dict:
-            args["toolchain_crn"] = _dict.get("toolchain_crn")
+            raise ValueError('Required property \'toolchain_id\' not present in ToolchainToolPatch JSON')
+        if (toolchain_crn := _dict.get('toolchain_crn')) is not None:
+            args['toolchain_crn'] = toolchain_crn
         else:
-            raise ValueError("Required property 'toolchain_crn' not present in ToolchainToolPatch JSON")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+            raise ValueError('Required property \'toolchain_crn\' not present in ToolchainToolPatch JSON')
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainToolPatch JSON")
-        if "referent" in _dict:
-            args["referent"] = ToolModelReferent.from_dict(_dict.get("referent"))
+            raise ValueError('Required property \'href\' not present in ToolchainToolPatch JSON')
+        if (referent := _dict.get('referent')) is not None:
+            args['referent'] = ToolModelReferent.from_dict(referent)
         else:
-            raise ValueError("Required property 'referent' not present in ToolchainToolPatch JSON")
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
-        if "updated_at" in _dict:
-            args["updated_at"] = string_to_datetime(_dict.get("updated_at"))
+            raise ValueError('Required property \'referent\' not present in ToolchainToolPatch JSON')
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
+        if (updated_at := _dict.get('updated_at')) is not None:
+            args['updated_at'] = string_to_datetime(updated_at)
         else:
-            raise ValueError("Required property 'updated_at' not present in ToolchainToolPatch JSON")
-        if "parameters" in _dict:
-            args["parameters"] = _dict.get("parameters")
+            raise ValueError('Required property \'updated_at\' not present in ToolchainToolPatch JSON')
+        if (parameters := _dict.get('parameters')) is not None:
+            args['parameters'] = parameters
         else:
-            raise ValueError("Required property 'parameters' not present in ToolchainToolPatch JSON")
-        if "state" in _dict:
-            args["state"] = _dict.get("state")
+            raise ValueError('Required property \'parameters\' not present in ToolchainToolPatch JSON')
+        if (state := _dict.get('state')) is not None:
+            args['state'] = state
         else:
-            raise ValueError("Required property 'state' not present in ToolchainToolPatch JSON")
+            raise ValueError('Required property \'state\' not present in ToolchainToolPatch JSON')
         return cls(**args)
 
     @classmethod
@@ -3125,33 +3175,33 @@ class ToolchainToolPatch:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "id") and self.id is not None:
-            _dict["id"] = self.id
-        if hasattr(self, "resource_group_id") and self.resource_group_id is not None:
-            _dict["resource_group_id"] = self.resource_group_id
-        if hasattr(self, "crn") and self.crn is not None:
-            _dict["crn"] = self.crn
-        if hasattr(self, "tool_type_id") and self.tool_type_id is not None:
-            _dict["tool_type_id"] = self.tool_type_id
-        if hasattr(self, "toolchain_id") and self.toolchain_id is not None:
-            _dict["toolchain_id"] = self.toolchain_id
-        if hasattr(self, "toolchain_crn") and self.toolchain_crn is not None:
-            _dict["toolchain_crn"] = self.toolchain_crn
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
-        if hasattr(self, "referent") and self.referent is not None:
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'resource_group_id') and self.resource_group_id is not None:
+            _dict['resource_group_id'] = self.resource_group_id
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'tool_type_id') and self.tool_type_id is not None:
+            _dict['tool_type_id'] = self.tool_type_id
+        if hasattr(self, 'toolchain_id') and self.toolchain_id is not None:
+            _dict['toolchain_id'] = self.toolchain_id
+        if hasattr(self, 'toolchain_crn') and self.toolchain_crn is not None:
+            _dict['toolchain_crn'] = self.toolchain_crn
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
+        if hasattr(self, 'referent') and self.referent is not None:
             if isinstance(self.referent, dict):
-                _dict["referent"] = self.referent
+                _dict['referent'] = self.referent
             else:
-                _dict["referent"] = self.referent.to_dict()
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "updated_at") and self.updated_at is not None:
-            _dict["updated_at"] = datetime_to_string(self.updated_at)
-        if hasattr(self, "parameters") and self.parameters is not None:
-            _dict["parameters"] = self.parameters
-        if hasattr(self, "state") and self.state is not None:
-            _dict["state"] = self.state
+                _dict['referent'] = self.referent.to_dict()
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'updated_at') and self.updated_at is not None:
+            _dict['updated_at'] = datetime_to_string(self.updated_at)
+        if hasattr(self, 'parameters') and self.parameters is not None:
+            _dict['parameters'] = self.parameters
+        if hasattr(self, 'state') and self.state is not None:
+            _dict['state'] = self.state
         return _dict
 
     def _to_dict(self):
@@ -3162,13 +3212,13 @@ class ToolchainToolPatch:
         """Return a `str` version of this ToolchainToolPatch object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainToolPatch") -> bool:
+    def __eq__(self, other: 'ToolchainToolPatch') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainToolPatch") -> bool:
+    def __ne__(self, other: 'ToolchainToolPatch') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -3177,37 +3227,37 @@ class ToolchainToolPatch:
         Current configuration state of the tool.
         """
 
-        CONFIGURED = "configured"
-        CONFIGURING = "configuring"
-        MISCONFIGURED = "misconfigured"
-        UNCONFIGURED = "unconfigured"
+        CONFIGURED = 'configured'
+        CONFIGURING = 'configuring'
+        MISCONFIGURED = 'misconfigured'
+        UNCONFIGURED = 'unconfigured'
 
 
 class ToolchainToolPost:
     """
     POST tool response body.
 
-    :attr str id: Tool ID.
-    :attr str resource_group_id: Resource group where the tool is located.
-    :attr str crn: Tool CRN.
-    :attr str tool_type_id: The unique name of the provisioned tool. A table of
+    :param str id: Tool ID.
+    :param str resource_group_id: Resource group where the tool is located.
+    :param str crn: Tool CRN.
+    :param str tool_type_id: The unique name of the provisioned tool. A table of
           `tool_type_id` values corresponding to each tool integration can be found in the
           <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
-    :attr str toolchain_id: ID of toolchain which the tool is bound to.
-    :attr str toolchain_crn: CRN of toolchain which the tool is bound to.
-    :attr str href: URI representing the tool.
-    :attr ToolModelReferent referent: Information on URIs to access this resource
+    :param str toolchain_id: ID of toolchain which the tool is bound to.
+    :param str toolchain_crn: CRN of toolchain which the tool is bound to.
+    :param str href: URI representing the tool.
+    :param ToolModelReferent referent: Information on URIs to access this resource
           through the UI or API.
-    :attr str name: (optional) Name of the tool.
-    :attr datetime updated_at: Latest tool update timestamp.
-    :attr dict parameters: Unique key-value pairs representing parameters to be used
-          to create the tool. A list of parameters for each tool integration can be found
-          in the <a
+    :param str name: (optional) Name of the tool.
+    :param datetime updated_at: Latest tool update timestamp.
+    :param dict parameters: Unique key-value pairs representing parameters to be
+          used to create the tool. A list of parameters for each tool integration can be
+          found in the <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
-    :attr str state: Current configuration state of the tool.
+    :param str state: Current configuration state of the tool.
     """
 
     def __init__(
@@ -3219,12 +3269,12 @@ class ToolchainToolPost:
         toolchain_id: str,
         toolchain_crn: str,
         href: str,
-        referent: "ToolModelReferent",
+        referent: 'ToolModelReferent',
         updated_at: datetime,
         parameters: dict,
         state: str,
         *,
-        name: str = None,
+        name: Optional[str] = None,
     ) -> None:
         """
         Initialize a ToolchainToolPost object.
@@ -3265,55 +3315,55 @@ class ToolchainToolPost:
         self.state = state
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainToolPost":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainToolPost':
         """Initialize a ToolchainToolPost object from a json dictionary."""
         args = {}
-        if "id" in _dict:
-            args["id"] = _dict.get("id")
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
         else:
-            raise ValueError("Required property 'id' not present in ToolchainToolPost JSON")
-        if "resource_group_id" in _dict:
-            args["resource_group_id"] = _dict.get("resource_group_id")
+            raise ValueError('Required property \'id\' not present in ToolchainToolPost JSON')
+        if (resource_group_id := _dict.get('resource_group_id')) is not None:
+            args['resource_group_id'] = resource_group_id
         else:
-            raise ValueError("Required property 'resource_group_id' not present in ToolchainToolPost JSON")
-        if "crn" in _dict:
-            args["crn"] = _dict.get("crn")
+            raise ValueError('Required property \'resource_group_id\' not present in ToolchainToolPost JSON')
+        if (crn := _dict.get('crn')) is not None:
+            args['crn'] = crn
         else:
-            raise ValueError("Required property 'crn' not present in ToolchainToolPost JSON")
-        if "tool_type_id" in _dict:
-            args["tool_type_id"] = _dict.get("tool_type_id")
+            raise ValueError('Required property \'crn\' not present in ToolchainToolPost JSON')
+        if (tool_type_id := _dict.get('tool_type_id')) is not None:
+            args['tool_type_id'] = tool_type_id
         else:
-            raise ValueError("Required property 'tool_type_id' not present in ToolchainToolPost JSON")
-        if "toolchain_id" in _dict:
-            args["toolchain_id"] = _dict.get("toolchain_id")
+            raise ValueError('Required property \'tool_type_id\' not present in ToolchainToolPost JSON')
+        if (toolchain_id := _dict.get('toolchain_id')) is not None:
+            args['toolchain_id'] = toolchain_id
         else:
-            raise ValueError("Required property 'toolchain_id' not present in ToolchainToolPost JSON")
-        if "toolchain_crn" in _dict:
-            args["toolchain_crn"] = _dict.get("toolchain_crn")
+            raise ValueError('Required property \'toolchain_id\' not present in ToolchainToolPost JSON')
+        if (toolchain_crn := _dict.get('toolchain_crn')) is not None:
+            args['toolchain_crn'] = toolchain_crn
         else:
-            raise ValueError("Required property 'toolchain_crn' not present in ToolchainToolPost JSON")
-        if "href" in _dict:
-            args["href"] = _dict.get("href")
+            raise ValueError('Required property \'toolchain_crn\' not present in ToolchainToolPost JSON')
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
         else:
-            raise ValueError("Required property 'href' not present in ToolchainToolPost JSON")
-        if "referent" in _dict:
-            args["referent"] = ToolModelReferent.from_dict(_dict.get("referent"))
+            raise ValueError('Required property \'href\' not present in ToolchainToolPost JSON')
+        if (referent := _dict.get('referent')) is not None:
+            args['referent'] = ToolModelReferent.from_dict(referent)
         else:
-            raise ValueError("Required property 'referent' not present in ToolchainToolPost JSON")
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
-        if "updated_at" in _dict:
-            args["updated_at"] = string_to_datetime(_dict.get("updated_at"))
+            raise ValueError('Required property \'referent\' not present in ToolchainToolPost JSON')
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
+        if (updated_at := _dict.get('updated_at')) is not None:
+            args['updated_at'] = string_to_datetime(updated_at)
         else:
-            raise ValueError("Required property 'updated_at' not present in ToolchainToolPost JSON")
-        if "parameters" in _dict:
-            args["parameters"] = _dict.get("parameters")
+            raise ValueError('Required property \'updated_at\' not present in ToolchainToolPost JSON')
+        if (parameters := _dict.get('parameters')) is not None:
+            args['parameters'] = parameters
         else:
-            raise ValueError("Required property 'parameters' not present in ToolchainToolPost JSON")
-        if "state" in _dict:
-            args["state"] = _dict.get("state")
+            raise ValueError('Required property \'parameters\' not present in ToolchainToolPost JSON')
+        if (state := _dict.get('state')) is not None:
+            args['state'] = state
         else:
-            raise ValueError("Required property 'state' not present in ToolchainToolPost JSON")
+            raise ValueError('Required property \'state\' not present in ToolchainToolPost JSON')
         return cls(**args)
 
     @classmethod
@@ -3324,33 +3374,33 @@ class ToolchainToolPost:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "id") and self.id is not None:
-            _dict["id"] = self.id
-        if hasattr(self, "resource_group_id") and self.resource_group_id is not None:
-            _dict["resource_group_id"] = self.resource_group_id
-        if hasattr(self, "crn") and self.crn is not None:
-            _dict["crn"] = self.crn
-        if hasattr(self, "tool_type_id") and self.tool_type_id is not None:
-            _dict["tool_type_id"] = self.tool_type_id
-        if hasattr(self, "toolchain_id") and self.toolchain_id is not None:
-            _dict["toolchain_id"] = self.toolchain_id
-        if hasattr(self, "toolchain_crn") and self.toolchain_crn is not None:
-            _dict["toolchain_crn"] = self.toolchain_crn
-        if hasattr(self, "href") and self.href is not None:
-            _dict["href"] = self.href
-        if hasattr(self, "referent") and self.referent is not None:
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'resource_group_id') and self.resource_group_id is not None:
+            _dict['resource_group_id'] = self.resource_group_id
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'tool_type_id') and self.tool_type_id is not None:
+            _dict['tool_type_id'] = self.tool_type_id
+        if hasattr(self, 'toolchain_id') and self.toolchain_id is not None:
+            _dict['toolchain_id'] = self.toolchain_id
+        if hasattr(self, 'toolchain_crn') and self.toolchain_crn is not None:
+            _dict['toolchain_crn'] = self.toolchain_crn
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
+        if hasattr(self, 'referent') and self.referent is not None:
             if isinstance(self.referent, dict):
-                _dict["referent"] = self.referent
+                _dict['referent'] = self.referent
             else:
-                _dict["referent"] = self.referent.to_dict()
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "updated_at") and self.updated_at is not None:
-            _dict["updated_at"] = datetime_to_string(self.updated_at)
-        if hasattr(self, "parameters") and self.parameters is not None:
-            _dict["parameters"] = self.parameters
-        if hasattr(self, "state") and self.state is not None:
-            _dict["state"] = self.state
+                _dict['referent'] = self.referent.to_dict()
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'updated_at') and self.updated_at is not None:
+            _dict['updated_at'] = datetime_to_string(self.updated_at)
+        if hasattr(self, 'parameters') and self.parameters is not None:
+            _dict['parameters'] = self.parameters
+        if hasattr(self, 'state') and self.state is not None:
+            _dict['state'] = self.state
         return _dict
 
     def _to_dict(self):
@@ -3361,13 +3411,13 @@ class ToolchainToolPost:
         """Return a `str` version of this ToolchainToolPost object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainToolPost") -> bool:
+    def __eq__(self, other: 'ToolchainToolPost') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainToolPost") -> bool:
+    def __ne__(self, other: 'ToolchainToolPost') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -3376,25 +3426,25 @@ class ToolchainToolPost:
         Current configuration state of the tool.
         """
 
-        CONFIGURED = "configured"
-        CONFIGURING = "configuring"
-        MISCONFIGURED = "misconfigured"
-        UNCONFIGURED = "unconfigured"
+        CONFIGURED = 'configured'
+        CONFIGURING = 'configuring'
+        MISCONFIGURED = 'misconfigured'
+        UNCONFIGURED = 'unconfigured'
 
 
 class ToolchainToolPrototypePatch:
     """
     Details on the new tool.
 
-    :attr str name: (optional) Name of the tool.
-    :attr str tool_type_id: (optional) The unique short name of the tool that should
-          be provisioned or updated. A table of `tool_type_id` values corresponding to
-          each tool integration can be found in the <a
+    :param str name: (optional) Name of the tool.
+    :param str tool_type_id: (optional) The unique short name of the tool that
+          should be provisioned or updated. A table of `tool_type_id` values corresponding
+          to each tool integration can be found in the <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
-    :attr dict parameters: (optional) Unique key-value pairs representing parameters
-          to be used to create the tool. A list of parameters for each tool integration
-          can be found in the <a
+    :param dict parameters: (optional) Unique key-value pairs representing
+          parameters to be used to create the tool. A list of parameters for each tool
+          integration can be found in the <a
           href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring
           tool integrations page</a>.
     """
@@ -3402,9 +3452,9 @@ class ToolchainToolPrototypePatch:
     def __init__(
         self,
         *,
-        name: str = None,
-        tool_type_id: str = None,
-        parameters: dict = None,
+        name: Optional[str] = None,
+        tool_type_id: Optional[str] = None,
+        parameters: Optional[dict] = None,
     ) -> None:
         """
         Initialize a ToolchainToolPrototypePatch object.
@@ -3426,15 +3476,15 @@ class ToolchainToolPrototypePatch:
         self.parameters = parameters
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> "ToolchainToolPrototypePatch":
+    def from_dict(cls, _dict: Dict) -> 'ToolchainToolPrototypePatch':
         """Initialize a ToolchainToolPrototypePatch object from a json dictionary."""
         args = {}
-        if "name" in _dict:
-            args["name"] = _dict.get("name")
-        if "tool_type_id" in _dict:
-            args["tool_type_id"] = _dict.get("tool_type_id")
-        if "parameters" in _dict:
-            args["parameters"] = _dict.get("parameters")
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
+        if (tool_type_id := _dict.get('tool_type_id')) is not None:
+            args['tool_type_id'] = tool_type_id
+        if (parameters := _dict.get('parameters')) is not None:
+            args['parameters'] = parameters
         return cls(**args)
 
     @classmethod
@@ -3445,12 +3495,12 @@ class ToolchainToolPrototypePatch:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, "name") and self.name is not None:
-            _dict["name"] = self.name
-        if hasattr(self, "tool_type_id") and self.tool_type_id is not None:
-            _dict["tool_type_id"] = self.tool_type_id
-        if hasattr(self, "parameters") and self.parameters is not None:
-            _dict["parameters"] = self.parameters
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'tool_type_id') and self.tool_type_id is not None:
+            _dict['tool_type_id'] = self.tool_type_id
+        if hasattr(self, 'parameters') and self.parameters is not None:
+            _dict['parameters'] = self.parameters
         return _dict
 
     def _to_dict(self):
@@ -3461,13 +3511,13 @@ class ToolchainToolPrototypePatch:
         """Return a `str` version of this ToolchainToolPrototypePatch object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: "ToolchainToolPrototypePatch") -> bool:
+    def __eq__(self, other: 'ToolchainToolPrototypePatch') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: "ToolchainToolPrototypePatch") -> bool:
+    def __ne__(self, other: 'ToolchainToolPrototypePatch') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -3500,7 +3550,7 @@ class ToolchainsPager:
         """
         self._has_next = True
         self._client = client
-        self._page_context = {"next": None}
+        self._page_context = {'next': None}
         self._resource_group_id = resource_group_id
         self._limit = limit
         self._name = name
@@ -3518,24 +3568,24 @@ class ToolchainsPager:
         :rtype: List[dict]
         """
         if not self.has_next():
-            raise StopIteration(message="No more results available")
+            raise StopIteration(message='No more results available')
 
         result = self._client.list_toolchains(
             resource_group_id=self._resource_group_id,
             limit=self._limit,
             name=self._name,
-            start=self._page_context.get("next"),
+            start=self._page_context.get('next'),
         ).get_result()
 
         next = None
-        next_page_link = result.get("next")
+        next_page_link = result.get('next')
         if next_page_link is not None:
-            next = next_page_link.get("start")
-        self._page_context["next"] = next
+            next = next_page_link.get('start')
+        self._page_context['next'] = next
         if next is None:
             self._has_next = False
 
-        return result.get("toolchains")
+        return result.get('toolchains')
 
     def get_all(self) -> List[dict]:
         """
@@ -3570,7 +3620,7 @@ class ToolsPager:
         """
         self._has_next = True
         self._client = client
-        self._page_context = {"next": None}
+        self._page_context = {'next': None}
         self._toolchain_id = toolchain_id
         self._limit = limit
 
@@ -3587,23 +3637,23 @@ class ToolsPager:
         :rtype: List[dict]
         """
         if not self.has_next():
-            raise StopIteration(message="No more results available")
+            raise StopIteration(message='No more results available')
 
         result = self._client.list_tools(
             toolchain_id=self._toolchain_id,
             limit=self._limit,
-            start=self._page_context.get("next"),
+            start=self._page_context.get('next'),
         ).get_result()
 
         next = None
-        next_page_link = result.get("next")
+        next_page_link = result.get('next')
         if next_page_link is not None:
-            next = next_page_link.get("start")
-        self._page_context["next"] = next
+            next = next_page_link.get('start')
+        self._page_context['next'] = next
         if next is None:
             self._has_next = False
 
-        return result.get("tools")
+        return result.get('tools')
 
     def get_all(self) -> List[dict]:
         """

--- a/test/integration/test_cd_toolchain_v2.py
+++ b/test/integration/test_cd_toolchain_v2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2023.
+# (C) Copyright IBM Corp. 2024.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import pytest
 from ibm_continuous_delivery.cd_toolchain_v2 import *
 
 # Config file name
-config_file = "cd_toolchain_v2.env"
+config_file = 'cd_toolchain_v2.env'
 
 # Variables to hold link values
 tool_id_link = None
@@ -49,7 +49,7 @@ class TestCdToolchainV2:
     @classmethod
     def setup_class(cls):
         if os.path.exists(config_file):
-            os.environ["IBM_CREDENTIALS_FILE"] = config_file
+            os.environ['IBM_CREDENTIALS_FILE'] = config_file
 
             cls.cd_toolchain_service = CdToolchainV2.new_instance()
             assert cls.cd_toolchain_service is not None
@@ -59,11 +59,10 @@ class TestCdToolchainV2:
 
             cls.cd_toolchain_service.enable_retries()
 
-        print("Setup complete.")
+        print('Setup complete.')
 
     needscredentials = pytest.mark.skipif(
-        not os.path.exists(config_file),
-        reason="External configuration not available, skipping...",
+        not os.path.exists(config_file), reason="External configuration not available, skipping..."
     )
 
     @needscredentials
@@ -80,7 +79,7 @@ class TestCdToolchainV2:
         toolchain_post = response.get_result()
         assert toolchain_post is not None
 
-        toolchain_id_link = toolchain_post["id"]
+        toolchain_id_link = toolchain_post['id']
 
     @needscredentials
     def test_create_tool(self):
@@ -88,16 +87,16 @@ class TestCdToolchainV2:
 
         response = self.cd_toolchain_service.create_tool(
             toolchain_id=toolchain_id_link,
-            tool_type_id="draservicebroker",
-            name="testString",
-            parameters={"anyKey": "anyValue"},
+            tool_type_id='draservicebroker',
+            name='testString',
+            parameters={'anyKey': 'anyValue'},
         )
 
         assert response.get_status_code() == 201
         toolchain_tool_post = response.get_result()
         assert toolchain_tool_post is not None
 
-        tool_id_link = toolchain_tool_post["id"]
+        tool_id_link = toolchain_tool_post['id']
 
     @needscredentials
     def test_list_toolchains(self):
@@ -156,8 +155,8 @@ class TestCdToolchainV2:
     def test_update_toolchain(self):
         # Construct a dict representation of a ToolchainPrototypePatch model
         toolchain_prototype_patch_model = {
-            "name": "newToolchainName",
-            "description": "New toolchain description",
+            'name': 'newToolchainName',
+            'description': 'New toolchain description',
         }
 
         response = self.cd_toolchain_service.update_toolchain(
@@ -185,25 +184,45 @@ class TestCdToolchainV2:
         assert toolchain_tool_post is not None
 
     @needscredentials
-    def test_create_toolchain_event(self):
+    def test_create_toolchain_event_application_json(self):
         # Construct a dict representation of a ToolchainEventPrototypeDataApplicationJson model
         toolchain_event_prototype_data_application_json_model = {
-            "content": {
-                "customKey1": "myCustomData",
-                "customKey2": 123,
-                "customKey3": {"nestedKey": "moreData"},
-            },
+            'content': {'customKey1': 'myCustomData', 'customKey2': 123, 'customKey3': {'nestedKey': 'moreData'}},
         }
+
         # Construct a dict representation of a ToolchainEventPrototypeData model
         toolchain_event_prototype_data_model = {
-            "application_json": toolchain_event_prototype_data_application_json_model,
+            'application_json': toolchain_event_prototype_data_application_json_model,
         }
 
         response = self.cd_toolchain_service.create_toolchain_event(
             toolchain_id=toolchain_id_link,
-            title="My-custom-event",
-            description="This is my custom event",
-            content_type="application/json",
+            title='My-custom-event',
+            description='This is my custom event',
+            content_type='application/json',
+            data=toolchain_event_prototype_data_model,
+        )
+
+        assert response.get_status_code() == 200
+        toolchain_event_post = response.get_result()
+        assert toolchain_event_post is not None
+
+    @needscredentials
+    def test_create_toolchain_event_text_plain(self):
+        # Construct a dict representation of a ToolchainEventPrototypeDataTextPlain model
+        toolchain_event_prototype_data_text_plain_model = {
+            'content': 'This event is dispatched because the pipeline failed',
+        }
+        # Construct a dict representation of a ToolchainEventPrototypeData model
+        toolchain_event_prototype_data_model = {
+            'text_plain': toolchain_event_prototype_data_text_plain_model,
+        }
+
+        response = self.cd_toolchain_service.create_toolchain_event(
+            toolchain_id=toolchain_id_link,
+            title='My-custom-event',
+            description='This is my custom event',
+            content_type='text/plain',
             data=toolchain_event_prototype_data_model,
         )
 
@@ -247,7 +266,7 @@ class TestCdToolchainV2:
         assert all_items is not None
 
         assert len(all_results) == len(all_items)
-        print(f"\nlist_tools() returned a total of {len(all_results)} items(s) using ToolsPager.")
+        print(f'\nlist_tools() returned a total of {len(all_results)} items(s) using ToolsPager.')
 
     @needscredentials
     def test_get_tool_by_id(self):
@@ -264,9 +283,9 @@ class TestCdToolchainV2:
     def test_update_tool(self):
         # Construct a dict representation of a ToolchainToolPrototypePatch model
         toolchain_tool_prototype_patch_model = {
-            "name": "MyTool",
-            "tool_type_id": "draservicebroker",
-            "parameters": {"anyKey": "anyValue"},
+            'name': 'MyTool',
+            'tool_type_id': 'draservicebroker',
+            'parameters': {'anyKey': 'anyValue'},
         }
 
         response = self.cd_toolchain_service.update_tool(

--- a/test/unit/test_cd_toolchain_v2.py
+++ b/test/unit/test_cd_toolchain_v2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2023.
+# (C) Copyright IBM Corp. 2024.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ from ibm_continuous_delivery.cd_toolchain_v2 import *
 
 _service = CdToolchainV2(authenticator=NoAuthAuthenticator())
 
-_base_url = "https://api.us-south.devops.cloud.ibm.com/toolchain/v2"
+_base_url = 'https://api.us-south.devops.cloud.ibm.com/toolchain/v2'
 _service.set_service_url(_base_url)
 
 
@@ -44,44 +44,36 @@ def preprocess_url(operation_path: str):
     The returned request URL is used to register the mock response so it needs
     to match the request URL that is formed by the requests library.
     """
-    # First, unquote the path since it might have some quoted/escaped characters in it
-    # due to how the generator inserts the operation paths into the unit test code.
-    operation_path = urllib.parse.unquote(operation_path)
 
-    # Next, quote the path using urllib so that we approximate what will
-    # happen during request processing.
-    operation_path = urllib.parse.quote(operation_path, safe="/")
-
-    # Finally, form the request URL from the base URL and operation path.
+    # Form the request URL from the base URL and operation path.
     request_url = _base_url + operation_path
 
     # If the request url does NOT end with a /, then just return it as-is.
     # Otherwise, return a regular expression that matches one or more trailing /.
-    if not request_url.endswith("/"):
+    if not request_url.endswith('/'):
         return request_url
-    else:
-        return re.compile(request_url.rstrip("/") + "/+")
+    return re.compile(request_url.rstrip('/') + '/+')
 
 
 def test_get_service_url_for_region():
     """
     get_service_url_for_region()
     """
-    assert CdToolchainV2.get_service_url_for_region("INVALID_REGION") is None
+    assert CdToolchainV2.get_service_url_for_region('INVALID_REGION') is None
     assert (
-        CdToolchainV2.get_service_url_for_region("us-south") == "https://api.us-south.devops.cloud.ibm.com/toolchain/v2"
+        CdToolchainV2.get_service_url_for_region('us-south') == 'https://api.us-south.devops.cloud.ibm.com/toolchain/v2'
     )
     assert (
-        CdToolchainV2.get_service_url_for_region("us-east") == "https://api.us-east.devops.cloud.ibm.com/toolchain/v2"
+        CdToolchainV2.get_service_url_for_region('us-east') == 'https://api.us-east.devops.cloud.ibm.com/toolchain/v2'
     )
-    assert CdToolchainV2.get_service_url_for_region("eu-de") == "https://api.eu-de.devops.cloud.ibm.com/toolchain/v2"
-    assert CdToolchainV2.get_service_url_for_region("eu-gb") == "https://api.eu-gb.devops.cloud.ibm.com/toolchain/v2"
-    assert CdToolchainV2.get_service_url_for_region("jp-osa") == "https://api.jp-osa.devops.cloud.ibm.com/toolchain/v2"
-    assert CdToolchainV2.get_service_url_for_region("jp-tok") == "https://api.jp-tok.devops.cloud.ibm.com/toolchain/v2"
-    assert CdToolchainV2.get_service_url_for_region("au-syd") == "https://api.au-syd.devops.cloud.ibm.com/toolchain/v2"
-    assert CdToolchainV2.get_service_url_for_region("ca-tor") == "https://api.ca-tor.devops.cloud.ibm.com/toolchain/v2"
-    assert CdToolchainV2.get_service_url_for_region("br-sao") == "https://api.br-sao.devops.cloud.ibm.com/toolchain/v2"
-    assert CdToolchainV2.get_service_url_for_region("eu-es") == "https://api.eu-es.devops.cloud.ibm.com/toolchain/v2"
+    assert CdToolchainV2.get_service_url_for_region('eu-de') == 'https://api.eu-de.devops.cloud.ibm.com/toolchain/v2'
+    assert CdToolchainV2.get_service_url_for_region('eu-gb') == 'https://api.eu-gb.devops.cloud.ibm.com/toolchain/v2'
+    assert CdToolchainV2.get_service_url_for_region('jp-osa') == 'https://api.jp-osa.devops.cloud.ibm.com/toolchain/v2'
+    assert CdToolchainV2.get_service_url_for_region('jp-tok') == 'https://api.jp-tok.devops.cloud.ibm.com/toolchain/v2'
+    assert CdToolchainV2.get_service_url_for_region('au-syd') == 'https://api.au-syd.devops.cloud.ibm.com/toolchain/v2'
+    assert CdToolchainV2.get_service_url_for_region('ca-tor') == 'https://api.ca-tor.devops.cloud.ibm.com/toolchain/v2'
+    assert CdToolchainV2.get_service_url_for_region('br-sao') == 'https://api.br-sao.devops.cloud.ibm.com/toolchain/v2'
+    assert CdToolchainV2.get_service_url_for_region('eu-es') == 'https://api.eu-es.devops.cloud.ibm.com/toolchain/v2'
 
 
 ##############################################################################
@@ -99,10 +91,10 @@ class TestNewInstance:
         """
         new_instance()
         """
-        os.environ["TEST_SERVICE_AUTH_TYPE"] = "noAuth"
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
 
         service = CdToolchainV2.new_instance(
-            service_name="TEST_SERVICE",
+            service_name='TEST_SERVICE',
         )
 
         assert service is not None
@@ -112,9 +104,9 @@ class TestNewInstance:
         """
         new_instance_without_authenticator()
         """
-        with pytest.raises(ValueError, match="authenticator must be provided"):
+        with pytest.raises(ValueError, match='authenticator must be provided'):
             service = CdToolchainV2.new_instance(
-                service_name="TEST_SERVICE_NOT_FOUND",
+                service_name='TEST_SERVICE_NOT_FOUND',
             )
 
 
@@ -129,21 +121,21 @@ class TestListToolchains:
         list_toolchains()
         """
         # Set up mock
-        url = preprocess_url("/toolchains")
+        url = preprocess_url('/toolchains')
         mock_response = '{"total_count": 11, "limit": 5, "first": {"href": "href"}, "previous": {"start": "start", "href": "href"}, "next": {"start": "start", "href": "href"}, "last": {"start": "start", "href": "href"}, "toolchains": [{"id": "id", "name": "TestToolchainV2", "description": "A sample toolchain to test the API", "account_id": "account_id", "location": "location", "resource_group_id": "6a9a01f2cff54a7f966f803d92877123", "crn": "crn", "href": "href", "ui_href": "ui_href", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "created_by"}]}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        resource_group_id = "6a9a01f2cff54a7f966f803d92877123"
+        resource_group_id = '6a9a01f2cff54a7f966f803d92877123'
         limit = 20
-        start = "testString"
-        name = "TestToolchainV2"
+        start = 'testString'
+        name = 'TestToolchainV2'
 
         # Invoke method
         response = _service.list_toolchains(
@@ -158,12 +150,12 @@ class TestListToolchains:
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split("?", 1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
-        assert "resource_group_id={}".format(resource_group_id) in query_string
-        assert "limit={}".format(limit) in query_string
-        assert "start={}".format(start) in query_string
-        assert "name={}".format(name) in query_string
+        assert 'resource_group_id={}'.format(resource_group_id) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
+        assert 'name={}'.format(name) in query_string
 
     def test_list_toolchains_all_params_with_retries(self):
         # Enable retries and run test_list_toolchains_all_params.
@@ -180,18 +172,18 @@ class TestListToolchains:
         test_list_toolchains_required_params()
         """
         # Set up mock
-        url = preprocess_url("/toolchains")
+        url = preprocess_url('/toolchains')
         mock_response = '{"total_count": 11, "limit": 5, "first": {"href": "href"}, "previous": {"start": "start", "href": "href"}, "next": {"start": "start", "href": "href"}, "last": {"start": "start", "href": "href"}, "toolchains": [{"id": "id", "name": "TestToolchainV2", "description": "A sample toolchain to test the API", "account_id": "account_id", "location": "location", "resource_group_id": "6a9a01f2cff54a7f966f803d92877123", "crn": "crn", "href": "href", "ui_href": "ui_href", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "created_by"}]}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        resource_group_id = "6a9a01f2cff54a7f966f803d92877123"
+        resource_group_id = '6a9a01f2cff54a7f966f803d92877123'
 
         # Invoke method
         response = _service.list_toolchains(
@@ -203,9 +195,9 @@ class TestListToolchains:
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split("?", 1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
-        assert "resource_group_id={}".format(resource_group_id) in query_string
+        assert 'resource_group_id={}'.format(resource_group_id) in query_string
 
     def test_list_toolchains_required_params_with_retries(self):
         # Enable retries and run test_list_toolchains_required_params.
@@ -222,18 +214,18 @@ class TestListToolchains:
         test_list_toolchains_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains")
+        url = preprocess_url('/toolchains')
         mock_response = '{"total_count": 11, "limit": 5, "first": {"href": "href"}, "previous": {"start": "start", "href": "href"}, "next": {"start": "start", "href": "href"}, "last": {"start": "start", "href": "href"}, "toolchains": [{"id": "id", "name": "TestToolchainV2", "description": "A sample toolchain to test the API", "account_id": "account_id", "location": "location", "resource_group_id": "6a9a01f2cff54a7f966f803d92877123", "crn": "crn", "href": "href", "ui_href": "ui_href", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "created_by"}]}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        resource_group_id = "6a9a01f2cff54a7f966f803d92877123"
+        resource_group_id = '6a9a01f2cff54a7f966f803d92877123'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -259,21 +251,21 @@ class TestListToolchains:
         test_list_toolchains_with_pager_get_next()
         """
         # Set up a two-page mock response
-        url = preprocess_url("/toolchains")
+        url = preprocess_url('/toolchains')
         mock_response1 = '{"next":{"start":"1"},"total_count":2,"toolchains":[{"id":"id","name":"TestToolchainV2","description":"A sample toolchain to test the API","account_id":"account_id","location":"location","resource_group_id":"6a9a01f2cff54a7f966f803d92877123","crn":"crn","href":"href","ui_href":"ui_href","created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","created_by":"created_by"}],"limit":1}'
         mock_response2 = '{"total_count":2,"toolchains":[{"id":"id","name":"TestToolchainV2","description":"A sample toolchain to test the API","account_id":"account_id","location":"location","resource_group_id":"6a9a01f2cff54a7f966f803d92877123","crn":"crn","href":"href","ui_href":"ui_href","created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","created_by":"created_by"}],"limit":1}'
         responses.add(
             responses.GET,
             url,
             body=mock_response1,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
         responses.add(
             responses.GET,
             url,
             body=mock_response2,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
@@ -281,9 +273,9 @@ class TestListToolchains:
         all_results = []
         pager = ToolchainsPager(
             client=_service,
-            resource_group_id="6a9a01f2cff54a7f966f803d92877123",
+            resource_group_id='6a9a01f2cff54a7f966f803d92877123',
             limit=10,
-            name="TestToolchainV2",
+            name='TestToolchainV2',
         )
         while pager.has_next():
             next_page = pager.get_next()
@@ -297,30 +289,30 @@ class TestListToolchains:
         test_list_toolchains_with_pager_get_all()
         """
         # Set up a two-page mock response
-        url = preprocess_url("/toolchains")
+        url = preprocess_url('/toolchains')
         mock_response1 = '{"next":{"start":"1"},"total_count":2,"toolchains":[{"id":"id","name":"TestToolchainV2","description":"A sample toolchain to test the API","account_id":"account_id","location":"location","resource_group_id":"6a9a01f2cff54a7f966f803d92877123","crn":"crn","href":"href","ui_href":"ui_href","created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","created_by":"created_by"}],"limit":1}'
         mock_response2 = '{"total_count":2,"toolchains":[{"id":"id","name":"TestToolchainV2","description":"A sample toolchain to test the API","account_id":"account_id","location":"location","resource_group_id":"6a9a01f2cff54a7f966f803d92877123","crn":"crn","href":"href","ui_href":"ui_href","created_at":"2019-01-01T12:00:00.000Z","updated_at":"2019-01-01T12:00:00.000Z","created_by":"created_by"}],"limit":1}'
         responses.add(
             responses.GET,
             url,
             body=mock_response1,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
         responses.add(
             responses.GET,
             url,
             body=mock_response2,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Exercise the pager class for this operation
         pager = ToolchainsPager(
             client=_service,
-            resource_group_id="6a9a01f2cff54a7f966f803d92877123",
+            resource_group_id='6a9a01f2cff54a7f966f803d92877123',
             limit=10,
-            name="TestToolchainV2",
+            name='TestToolchainV2',
         )
         all_results = pager.get_all()
         assert all_results is not None
@@ -338,20 +330,20 @@ class TestCreateToolchain:
         create_toolchain()
         """
         # Set up mock
-        url = preprocess_url("/toolchains")
+        url = preprocess_url('/toolchains')
         mock_response = '{"id": "id", "name": "TestToolchainV2", "description": "A sample toolchain to test the API", "account_id": "account_id", "location": "location", "resource_group_id": "6a9a01f2cff54a7f966f803d92877123", "crn": "crn", "href": "href", "ui_href": "ui_href", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "created_by"}'
         responses.add(
             responses.POST,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=201,
         )
 
         # Set up parameter values
-        name = "TestToolchainV2"
-        resource_group_id = "6a9a01f2cff54a7f966f803d92877123"
-        description = "A sample toolchain to test the API"
+        name = 'TestToolchainV2'
+        resource_group_id = '6a9a01f2cff54a7f966f803d92877123'
+        description = 'A sample toolchain to test the API'
 
         # Invoke method
         response = _service.create_toolchain(
@@ -365,10 +357,10 @@ class TestCreateToolchain:
         assert len(responses.calls) == 1
         assert response.status_code == 201
         # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, "utf-8"))
-        assert req_body["name"] == "TestToolchainV2"
-        assert req_body["resource_group_id"] == "6a9a01f2cff54a7f966f803d92877123"
-        assert req_body["description"] == "A sample toolchain to test the API"
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['name'] == 'TestToolchainV2'
+        assert req_body['resource_group_id'] == '6a9a01f2cff54a7f966f803d92877123'
+        assert req_body['description'] == 'A sample toolchain to test the API'
 
     def test_create_toolchain_all_params_with_retries(self):
         # Enable retries and run test_create_toolchain_all_params.
@@ -385,20 +377,20 @@ class TestCreateToolchain:
         test_create_toolchain_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains")
+        url = preprocess_url('/toolchains')
         mock_response = '{"id": "id", "name": "TestToolchainV2", "description": "A sample toolchain to test the API", "account_id": "account_id", "location": "location", "resource_group_id": "6a9a01f2cff54a7f966f803d92877123", "crn": "crn", "href": "href", "ui_href": "ui_href", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "created_by"}'
         responses.add(
             responses.POST,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=201,
         )
 
         # Set up parameter values
-        name = "TestToolchainV2"
-        resource_group_id = "6a9a01f2cff54a7f966f803d92877123"
-        description = "A sample toolchain to test the API"
+        name = 'TestToolchainV2'
+        resource_group_id = '6a9a01f2cff54a7f966f803d92877123'
+        description = 'A sample toolchain to test the API'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -431,18 +423,18 @@ class TestGetToolchainById:
         get_toolchain_by_id()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString")
+        url = preprocess_url('/toolchains/testString')
         mock_response = '{"id": "id", "name": "TestToolchainV2", "description": "A sample toolchain to test the API", "account_id": "account_id", "location": "location", "resource_group_id": "6a9a01f2cff54a7f966f803d92877123", "crn": "crn", "href": "href", "ui_href": "ui_href", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "created_by"}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
+        toolchain_id = 'testString'
 
         # Invoke method
         response = _service.get_toolchain_by_id(
@@ -469,18 +461,18 @@ class TestGetToolchainById:
         test_get_toolchain_by_id_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString")
+        url = preprocess_url('/toolchains/testString')
         mock_response = '{"id": "id", "name": "TestToolchainV2", "description": "A sample toolchain to test the API", "account_id": "account_id", "location": "location", "resource_group_id": "6a9a01f2cff54a7f966f803d92877123", "crn": "crn", "href": "href", "ui_href": "ui_href", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "created_by"}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
+        toolchain_id = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -512,7 +504,7 @@ class TestDeleteToolchain:
         delete_toolchain()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString")
+        url = preprocess_url('/toolchains/testString')
         responses.add(
             responses.DELETE,
             url,
@@ -520,7 +512,7 @@ class TestDeleteToolchain:
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
+        toolchain_id = 'testString'
 
         # Invoke method
         response = _service.delete_toolchain(
@@ -547,7 +539,7 @@ class TestDeleteToolchain:
         test_delete_toolchain_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString")
+        url = preprocess_url('/toolchains/testString')
         responses.add(
             responses.DELETE,
             url,
@@ -555,7 +547,7 @@ class TestDeleteToolchain:
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
+        toolchain_id = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -587,23 +579,23 @@ class TestUpdateToolchain:
         update_toolchain()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString")
+        url = preprocess_url('/toolchains/testString')
         mock_response = '{"id": "id", "name": "TestToolchainV2", "description": "A sample toolchain to test the API", "account_id": "account_id", "location": "location", "resource_group_id": "6a9a01f2cff54a7f966f803d92877123", "crn": "crn", "href": "href", "ui_href": "ui_href", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "created_by"}'
         responses.add(
             responses.PATCH,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Construct a dict representation of a ToolchainPrototypePatch model
         toolchain_prototype_patch_model = {}
-        toolchain_prototype_patch_model["name"] = "newToolchainName"
-        toolchain_prototype_patch_model["description"] = "New toolchain description"
+        toolchain_prototype_patch_model['name'] = 'newToolchainName'
+        toolchain_prototype_patch_model['description'] = 'New toolchain description'
 
         # Set up parameter values
-        toolchain_id = "testString"
+        toolchain_id = 'testString'
         toolchain_prototype_patch = toolchain_prototype_patch_model
 
         # Invoke method
@@ -617,7 +609,7 @@ class TestUpdateToolchain:
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, "utf-8"))
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body == toolchain_prototype_patch
 
     def test_update_toolchain_all_params_with_retries(self):
@@ -635,23 +627,23 @@ class TestUpdateToolchain:
         test_update_toolchain_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString")
+        url = preprocess_url('/toolchains/testString')
         mock_response = '{"id": "id", "name": "TestToolchainV2", "description": "A sample toolchain to test the API", "account_id": "account_id", "location": "location", "resource_group_id": "6a9a01f2cff54a7f966f803d92877123", "crn": "crn", "href": "href", "ui_href": "ui_href", "created_at": "2019-01-01T12:00:00.000Z", "updated_at": "2019-01-01T12:00:00.000Z", "created_by": "created_by"}'
         responses.add(
             responses.PATCH,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Construct a dict representation of a ToolchainPrototypePatch model
         toolchain_prototype_patch_model = {}
-        toolchain_prototype_patch_model["name"] = "newToolchainName"
-        toolchain_prototype_patch_model["description"] = "New toolchain description"
+        toolchain_prototype_patch_model['name'] = 'newToolchainName'
+        toolchain_prototype_patch_model['description'] = 'New toolchain description'
 
         # Set up parameter values
-        toolchain_id = "testString"
+        toolchain_id = 'testString'
         toolchain_prototype_patch = toolchain_prototype_patch_model
 
         # Pass in all but one required param and check for a ValueError
@@ -685,30 +677,33 @@ class TestCreateToolchainEvent:
         create_toolchain_event()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/events")
+        url = preprocess_url('/toolchains/testString/events')
         mock_response = '{"id": "id"}'
         responses.add(
             responses.POST,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Construct a dict representation of a ToolchainEventPrototypeDataApplicationJson model
         toolchain_event_prototype_data_application_json_model = {}
-        toolchain_event_prototype_data_application_json_model["content"] = {"anyKey": "anyValue"}
+        toolchain_event_prototype_data_application_json_model['content'] = {
+            'customKey1': 'myCustomData',
+            'customKey2': 123,
+            'customKey3': {'nestedKey': 'moreData'},
+        }
 
         # Construct a dict representation of a ToolchainEventPrototypeData model
         toolchain_event_prototype_data_model = {}
-        toolchain_event_prototype_data_model["application_json"] = toolchain_event_prototype_data_application_json_model
-        toolchain_event_prototype_data_model["text_plain"] = "This event is dispatched because the pipeline failed"
+        toolchain_event_prototype_data_model['application_json'] = toolchain_event_prototype_data_application_json_model
 
         # Set up parameter values
-        toolchain_id = "testString"
-        title = "My-custom-event"
-        description = "This is my custom event"
-        content_type = "application/json"
+        toolchain_id = 'testString'
+        title = 'My-custom-event'
+        description = 'This is my custom event'
+        content_type = 'application/json'
         data = toolchain_event_prototype_data_model
 
         # Invoke method
@@ -725,11 +720,11 @@ class TestCreateToolchainEvent:
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, "utf-8"))
-        assert req_body["title"] == "My-custom-event"
-        assert req_body["description"] == "This is my custom event"
-        assert req_body["content_type"] == "application/json"
-        assert req_body["data"] == toolchain_event_prototype_data_model
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['title'] == 'My-custom-event'
+        assert req_body['description'] == 'This is my custom event'
+        assert req_body['content_type'] == 'application/json'
+        assert req_body['data'] == toolchain_event_prototype_data_model
 
     def test_create_toolchain_event_all_params_with_retries(self):
         # Enable retries and run test_create_toolchain_event_all_params.
@@ -746,30 +741,40 @@ class TestCreateToolchainEvent:
         test_create_toolchain_event_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/events")
+        url = preprocess_url('/toolchains/testString/events')
         mock_response = '{"id": "id"}'
         responses.add(
             responses.POST,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Construct a dict representation of a ToolchainEventPrototypeDataApplicationJson model
         toolchain_event_prototype_data_application_json_model = {}
-        toolchain_event_prototype_data_application_json_model["content"] = {"anyKey": "anyValue"}
+        toolchain_event_prototype_data_application_json_model['content'] = {
+            'customKey1': 'myCustomData',
+            'customKey2': 123,
+            'customKey3': {'nestedKey': 'moreData'},
+        }
+
+        # Construct a dict representation of a ToolchainEventPrototypeDataTextPlain model
+        toolchain_event_prototype_data_text_plain_model = {}
+        toolchain_event_prototype_data_text_plain_model['content'] = (
+            'This event is dispatched because the pipeline failed'
+        )
 
         # Construct a dict representation of a ToolchainEventPrototypeData model
         toolchain_event_prototype_data_model = {}
-        toolchain_event_prototype_data_model["application_json"] = toolchain_event_prototype_data_application_json_model
-        toolchain_event_prototype_data_model["text_plain"] = "This event is dispatched because the pipeline failed"
+        toolchain_event_prototype_data_model['application_json'] = toolchain_event_prototype_data_application_json_model
+        toolchain_event_prototype_data_model['text_plain'] = toolchain_event_prototype_data_text_plain_model
 
         # Set up parameter values
-        toolchain_id = "testString"
-        title = "My-custom-event"
-        description = "This is my custom event"
-        content_type = "application/json"
+        toolchain_id = 'testString'
+        title = 'My-custom-event'
+        description = 'This is my custom event'
+        content_type = 'application/json'
         data = toolchain_event_prototype_data_model
 
         # Pass in all but one required param and check for a ValueError
@@ -814,10 +819,10 @@ class TestNewInstance:
         """
         new_instance()
         """
-        os.environ["TEST_SERVICE_AUTH_TYPE"] = "noAuth"
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
 
         service = CdToolchainV2.new_instance(
-            service_name="TEST_SERVICE",
+            service_name='TEST_SERVICE',
         )
 
         assert service is not None
@@ -827,9 +832,9 @@ class TestNewInstance:
         """
         new_instance_without_authenticator()
         """
-        with pytest.raises(ValueError, match="authenticator must be provided"):
+        with pytest.raises(ValueError, match='authenticator must be provided'):
             service = CdToolchainV2.new_instance(
-                service_name="TEST_SERVICE_NOT_FOUND",
+                service_name='TEST_SERVICE_NOT_FOUND',
             )
 
 
@@ -844,20 +849,20 @@ class TestListTools:
         list_tools()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools")
+        url = preprocess_url('/toolchains/testString/tools')
         mock_response = '{"limit": 5, "total_count": 11, "first": {"href": "href"}, "previous": {"start": "start", "href": "href"}, "next": {"start": "start", "href": "href"}, "last": {"start": "start", "href": "href"}, "tools": [{"id": "id", "resource_group_id": "resource_group_id", "crn": "crn", "tool_type_id": "tool_type_id", "toolchain_id": "toolchain_id", "toolchain_crn": "toolchain_crn", "href": "href", "referent": {"ui_href": "ui_href", "api_href": "api_href"}, "name": "MyTool", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}]}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
+        toolchain_id = 'testString'
         limit = 20
-        start = "testString"
+        start = 'testString'
 
         # Invoke method
         response = _service.list_tools(
@@ -871,10 +876,10 @@ class TestListTools:
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split("?", 1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
-        assert "limit={}".format(limit) in query_string
-        assert "start={}".format(start) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
 
     def test_list_tools_all_params_with_retries(self):
         # Enable retries and run test_list_tools_all_params.
@@ -891,18 +896,18 @@ class TestListTools:
         test_list_tools_required_params()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools")
+        url = preprocess_url('/toolchains/testString/tools')
         mock_response = '{"limit": 5, "total_count": 11, "first": {"href": "href"}, "previous": {"start": "start", "href": "href"}, "next": {"start": "start", "href": "href"}, "last": {"start": "start", "href": "href"}, "tools": [{"id": "id", "resource_group_id": "resource_group_id", "crn": "crn", "tool_type_id": "tool_type_id", "toolchain_id": "toolchain_id", "toolchain_crn": "toolchain_crn", "href": "href", "referent": {"ui_href": "ui_href", "api_href": "api_href"}, "name": "MyTool", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}]}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
+        toolchain_id = 'testString'
 
         # Invoke method
         response = _service.list_tools(
@@ -929,18 +934,18 @@ class TestListTools:
         test_list_tools_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools")
+        url = preprocess_url('/toolchains/testString/tools')
         mock_response = '{"limit": 5, "total_count": 11, "first": {"href": "href"}, "previous": {"start": "start", "href": "href"}, "next": {"start": "start", "href": "href"}, "last": {"start": "start", "href": "href"}, "tools": [{"id": "id", "resource_group_id": "resource_group_id", "crn": "crn", "tool_type_id": "tool_type_id", "toolchain_id": "toolchain_id", "toolchain_crn": "toolchain_crn", "href": "href", "referent": {"ui_href": "ui_href", "api_href": "api_href"}, "name": "MyTool", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}]}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
+        toolchain_id = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -966,21 +971,21 @@ class TestListTools:
         test_list_tools_with_pager_get_next()
         """
         # Set up a two-page mock response
-        url = preprocess_url("/toolchains/testString/tools")
+        url = preprocess_url('/toolchains/testString/tools')
         mock_response1 = '{"next":{"start":"1"},"total_count":2,"limit":1,"tools":[{"id":"id","resource_group_id":"resource_group_id","crn":"crn","tool_type_id":"tool_type_id","toolchain_id":"toolchain_id","toolchain_crn":"toolchain_crn","href":"href","referent":{"ui_href":"ui_href","api_href":"api_href"},"name":"MyTool","updated_at":"2019-01-01T12:00:00.000Z","parameters":{"anyKey":"anyValue"},"state":"configured"}]}'
         mock_response2 = '{"total_count":2,"limit":1,"tools":[{"id":"id","resource_group_id":"resource_group_id","crn":"crn","tool_type_id":"tool_type_id","toolchain_id":"toolchain_id","toolchain_crn":"toolchain_crn","href":"href","referent":{"ui_href":"ui_href","api_href":"api_href"},"name":"MyTool","updated_at":"2019-01-01T12:00:00.000Z","parameters":{"anyKey":"anyValue"},"state":"configured"}]}'
         responses.add(
             responses.GET,
             url,
             body=mock_response1,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
         responses.add(
             responses.GET,
             url,
             body=mock_response2,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
@@ -988,7 +993,7 @@ class TestListTools:
         all_results = []
         pager = ToolsPager(
             client=_service,
-            toolchain_id="testString",
+            toolchain_id='testString',
             limit=10,
         )
         while pager.has_next():
@@ -1003,28 +1008,28 @@ class TestListTools:
         test_list_tools_with_pager_get_all()
         """
         # Set up a two-page mock response
-        url = preprocess_url("/toolchains/testString/tools")
+        url = preprocess_url('/toolchains/testString/tools')
         mock_response1 = '{"next":{"start":"1"},"total_count":2,"limit":1,"tools":[{"id":"id","resource_group_id":"resource_group_id","crn":"crn","tool_type_id":"tool_type_id","toolchain_id":"toolchain_id","toolchain_crn":"toolchain_crn","href":"href","referent":{"ui_href":"ui_href","api_href":"api_href"},"name":"MyTool","updated_at":"2019-01-01T12:00:00.000Z","parameters":{"anyKey":"anyValue"},"state":"configured"}]}'
         mock_response2 = '{"total_count":2,"limit":1,"tools":[{"id":"id","resource_group_id":"resource_group_id","crn":"crn","tool_type_id":"tool_type_id","toolchain_id":"toolchain_id","toolchain_crn":"toolchain_crn","href":"href","referent":{"ui_href":"ui_href","api_href":"api_href"},"name":"MyTool","updated_at":"2019-01-01T12:00:00.000Z","parameters":{"anyKey":"anyValue"},"state":"configured"}]}'
         responses.add(
             responses.GET,
             url,
             body=mock_response1,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
         responses.add(
             responses.GET,
             url,
             body=mock_response2,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Exercise the pager class for this operation
         pager = ToolsPager(
             client=_service,
-            toolchain_id="testString",
+            toolchain_id='testString',
             limit=10,
         )
         all_results = pager.get_all()
@@ -1043,21 +1048,21 @@ class TestCreateTool:
         create_tool()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools")
+        url = preprocess_url('/toolchains/testString/tools')
         mock_response = '{"id": "id", "resource_group_id": "resource_group_id", "crn": "crn", "tool_type_id": "tool_type_id", "toolchain_id": "toolchain_id", "toolchain_crn": "toolchain_crn", "href": "href", "referent": {"ui_href": "ui_href", "api_href": "api_href"}, "name": "MyTool", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}'
         responses.add(
             responses.POST,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=201,
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
-        tool_type_id = "draservicebroker"
-        name = "testString"
-        parameters = {"anyKey": "anyValue"}
+        toolchain_id = 'testString'
+        tool_type_id = 'draservicebroker'
+        name = 'testString'
+        parameters = {'anyKey': 'anyValue'}
 
         # Invoke method
         response = _service.create_tool(
@@ -1072,10 +1077,10 @@ class TestCreateTool:
         assert len(responses.calls) == 1
         assert response.status_code == 201
         # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, "utf-8"))
-        assert req_body["tool_type_id"] == "draservicebroker"
-        assert req_body["name"] == "testString"
-        assert req_body["parameters"] == {"anyKey": "anyValue"}
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['tool_type_id'] == 'draservicebroker'
+        assert req_body['name'] == 'testString'
+        assert req_body['parameters'] == {'anyKey': 'anyValue'}
 
     def test_create_tool_all_params_with_retries(self):
         # Enable retries and run test_create_tool_all_params.
@@ -1092,21 +1097,21 @@ class TestCreateTool:
         test_create_tool_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools")
+        url = preprocess_url('/toolchains/testString/tools')
         mock_response = '{"id": "id", "resource_group_id": "resource_group_id", "crn": "crn", "tool_type_id": "tool_type_id", "toolchain_id": "toolchain_id", "toolchain_crn": "toolchain_crn", "href": "href", "referent": {"ui_href": "ui_href", "api_href": "api_href"}, "name": "MyTool", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}'
         responses.add(
             responses.POST,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=201,
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
-        tool_type_id = "draservicebroker"
-        name = "testString"
-        parameters = {"anyKey": "anyValue"}
+        toolchain_id = 'testString'
+        tool_type_id = 'draservicebroker'
+        name = 'testString'
+        parameters = {'anyKey': 'anyValue'}
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -1139,19 +1144,19 @@ class TestGetToolById:
         get_tool_by_id()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools/testString")
+        url = preprocess_url('/toolchains/testString/tools/testString')
         mock_response = '{"id": "id", "resource_group_id": "resource_group_id", "crn": "crn", "tool_type_id": "tool_type_id", "toolchain_id": "toolchain_id", "toolchain_crn": "toolchain_crn", "href": "href", "referent": {"ui_href": "ui_href", "api_href": "api_href"}, "name": "MyTool", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
-        tool_id = "testString"
+        toolchain_id = 'testString'
+        tool_id = 'testString'
 
         # Invoke method
         response = _service.get_tool_by_id(
@@ -1179,19 +1184,19 @@ class TestGetToolById:
         test_get_tool_by_id_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools/testString")
+        url = preprocess_url('/toolchains/testString/tools/testString')
         mock_response = '{"id": "id", "resource_group_id": "resource_group_id", "crn": "crn", "tool_type_id": "tool_type_id", "toolchain_id": "toolchain_id", "toolchain_crn": "toolchain_crn", "href": "href", "referent": {"ui_href": "ui_href", "api_href": "api_href"}, "name": "MyTool", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}'
         responses.add(
             responses.GET,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
-        tool_id = "testString"
+        toolchain_id = 'testString'
+        tool_id = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -1224,7 +1229,7 @@ class TestDeleteTool:
         delete_tool()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools/testString")
+        url = preprocess_url('/toolchains/testString/tools/testString')
         responses.add(
             responses.DELETE,
             url,
@@ -1232,8 +1237,8 @@ class TestDeleteTool:
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
-        tool_id = "testString"
+        toolchain_id = 'testString'
+        tool_id = 'testString'
 
         # Invoke method
         response = _service.delete_tool(
@@ -1261,7 +1266,7 @@ class TestDeleteTool:
         test_delete_tool_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools/testString")
+        url = preprocess_url('/toolchains/testString/tools/testString')
         responses.add(
             responses.DELETE,
             url,
@@ -1269,8 +1274,8 @@ class TestDeleteTool:
         )
 
         # Set up parameter values
-        toolchain_id = "testString"
-        tool_id = "testString"
+        toolchain_id = 'testString'
+        tool_id = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -1303,25 +1308,25 @@ class TestUpdateTool:
         update_tool()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools/testString")
+        url = preprocess_url('/toolchains/testString/tools/testString')
         mock_response = '{"id": "id", "resource_group_id": "resource_group_id", "crn": "crn", "tool_type_id": "tool_type_id", "toolchain_id": "toolchain_id", "toolchain_crn": "toolchain_crn", "href": "href", "referent": {"ui_href": "ui_href", "api_href": "api_href"}, "name": "MyTool", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}'
         responses.add(
             responses.PATCH,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Construct a dict representation of a ToolchainToolPrototypePatch model
         toolchain_tool_prototype_patch_model = {}
-        toolchain_tool_prototype_patch_model["name"] = "MyTool"
-        toolchain_tool_prototype_patch_model["tool_type_id"] = "draservicebroker"
-        toolchain_tool_prototype_patch_model["parameters"] = {"anyKey": "anyValue"}
+        toolchain_tool_prototype_patch_model['name'] = 'MyTool'
+        toolchain_tool_prototype_patch_model['tool_type_id'] = 'draservicebroker'
+        toolchain_tool_prototype_patch_model['parameters'] = {'anyKey': 'anyValue'}
 
         # Set up parameter values
-        toolchain_id = "testString"
-        tool_id = "testString"
+        toolchain_id = 'testString'
+        tool_id = 'testString'
         toolchain_tool_prototype_patch = toolchain_tool_prototype_patch_model
 
         # Invoke method
@@ -1336,7 +1341,7 @@ class TestUpdateTool:
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, "utf-8"))
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body == toolchain_tool_prototype_patch
 
     def test_update_tool_all_params_with_retries(self):
@@ -1354,25 +1359,25 @@ class TestUpdateTool:
         test_update_tool_value_error()
         """
         # Set up mock
-        url = preprocess_url("/toolchains/testString/tools/testString")
+        url = preprocess_url('/toolchains/testString/tools/testString')
         mock_response = '{"id": "id", "resource_group_id": "resource_group_id", "crn": "crn", "tool_type_id": "tool_type_id", "toolchain_id": "toolchain_id", "toolchain_crn": "toolchain_crn", "href": "href", "referent": {"ui_href": "ui_href", "api_href": "api_href"}, "name": "MyTool", "updated_at": "2019-01-01T12:00:00.000Z", "parameters": {"anyKey": "anyValue"}, "state": "configured"}'
         responses.add(
             responses.PATCH,
             url,
             body=mock_response,
-            content_type="application/json",
+            content_type='application/json',
             status=200,
         )
 
         # Construct a dict representation of a ToolchainToolPrototypePatch model
         toolchain_tool_prototype_patch_model = {}
-        toolchain_tool_prototype_patch_model["name"] = "MyTool"
-        toolchain_tool_prototype_patch_model["tool_type_id"] = "draservicebroker"
-        toolchain_tool_prototype_patch_model["parameters"] = {"anyKey": "anyValue"}
+        toolchain_tool_prototype_patch_model['name'] = 'MyTool'
+        toolchain_tool_prototype_patch_model['tool_type_id'] = 'draservicebroker'
+        toolchain_tool_prototype_patch_model['parameters'] = {'anyKey': 'anyValue'}
 
         # Set up parameter values
-        toolchain_id = "testString"
-        tool_id = "testString"
+        toolchain_id = 'testString'
+        tool_id = 'testString'
         toolchain_tool_prototype_patch = toolchain_tool_prototype_patch_model
 
         # Pass in all but one required param and check for a ValueError
@@ -1421,23 +1426,23 @@ class TestModel_ToolModel:
         # Construct dict forms of any model objects needed in order to build this model.
 
         tool_model_referent_model = {}  # ToolModelReferent
-        tool_model_referent_model["ui_href"] = "https://my-team.slack.com/messages/my-channel"
-        tool_model_referent_model["api_href"] = "testString"
+        tool_model_referent_model['ui_href'] = 'https://my-team.slack.com/messages/my-channel'
+        tool_model_referent_model['api_href'] = 'testString'
 
         # Construct a json representation of a ToolModel model
         tool_model_model_json = {}
-        tool_model_model_json["id"] = "testString"
-        tool_model_model_json["resource_group_id"] = "testString"
-        tool_model_model_json["crn"] = "testString"
-        tool_model_model_json["tool_type_id"] = "testString"
-        tool_model_model_json["toolchain_id"] = "testString"
-        tool_model_model_json["toolchain_crn"] = "testString"
-        tool_model_model_json["href"] = "testString"
-        tool_model_model_json["referent"] = tool_model_referent_model
-        tool_model_model_json["name"] = "MyTool"
-        tool_model_model_json["updated_at"] = "2019-01-01T12:00:00Z"
-        tool_model_model_json["parameters"] = {"anyKey": "anyValue"}
-        tool_model_model_json["state"] = "configured"
+        tool_model_model_json['id'] = 'testString'
+        tool_model_model_json['resource_group_id'] = 'testString'
+        tool_model_model_json['crn'] = 'testString'
+        tool_model_model_json['tool_type_id'] = 'testString'
+        tool_model_model_json['toolchain_id'] = 'testString'
+        tool_model_model_json['toolchain_crn'] = 'testString'
+        tool_model_model_json['href'] = 'testString'
+        tool_model_model_json['referent'] = tool_model_referent_model
+        tool_model_model_json['name'] = 'MyTool'
+        tool_model_model_json['updated_at'] = '2019-01-01T12:00:00Z'
+        tool_model_model_json['parameters'] = {'anyKey': 'anyValue'}
+        tool_model_model_json['state'] = 'configured'
 
         # Construct a model instance of ToolModel by calling from_dict on the json representation
         tool_model_model = ToolModel.from_dict(tool_model_model_json)
@@ -1467,8 +1472,8 @@ class TestModel_ToolModelReferent:
 
         # Construct a json representation of a ToolModelReferent model
         tool_model_referent_model_json = {}
-        tool_model_referent_model_json["ui_href"] = "testString"
-        tool_model_referent_model_json["api_href"] = "testString"
+        tool_model_referent_model_json['ui_href'] = 'testString'
+        tool_model_referent_model_json['api_href'] = 'testString'
 
         # Construct a model instance of ToolModelReferent by calling from_dict on the json representation
         tool_model_referent_model = ToolModelReferent.from_dict(tool_model_referent_model_json)
@@ -1498,18 +1503,18 @@ class TestModel_Toolchain:
 
         # Construct a json representation of a Toolchain model
         toolchain_model_json = {}
-        toolchain_model_json["id"] = "testString"
-        toolchain_model_json["name"] = "TestToolchainV2"
-        toolchain_model_json["description"] = "A sample toolchain to test the API"
-        toolchain_model_json["account_id"] = "testString"
-        toolchain_model_json["location"] = "testString"
-        toolchain_model_json["resource_group_id"] = "6a9a01f2cff54a7f966f803d92877123"
-        toolchain_model_json["crn"] = "testString"
-        toolchain_model_json["href"] = "testString"
-        toolchain_model_json["ui_href"] = "testString"
-        toolchain_model_json["created_at"] = "2019-01-01T12:00:00Z"
-        toolchain_model_json["updated_at"] = "2019-01-01T12:00:00Z"
-        toolchain_model_json["created_by"] = "testString"
+        toolchain_model_json['id'] = 'testString'
+        toolchain_model_json['name'] = 'TestToolchainV2'
+        toolchain_model_json['description'] = 'A sample toolchain to test the API'
+        toolchain_model_json['account_id'] = 'testString'
+        toolchain_model_json['location'] = 'testString'
+        toolchain_model_json['resource_group_id'] = '6a9a01f2cff54a7f966f803d92877123'
+        toolchain_model_json['crn'] = 'testString'
+        toolchain_model_json['href'] = 'testString'
+        toolchain_model_json['ui_href'] = 'testString'
+        toolchain_model_json['created_at'] = '2019-01-01T12:00:00Z'
+        toolchain_model_json['updated_at'] = '2019-01-01T12:00:00Z'
+        toolchain_model_json['created_by'] = 'testString'
 
         # Construct a model instance of Toolchain by calling from_dict on the json representation
         toolchain_model = Toolchain.from_dict(toolchain_model_json)
@@ -1540,61 +1545,61 @@ class TestModel_ToolchainCollection:
         # Construct dict forms of any model objects needed in order to build this model.
 
         toolchain_collection_first_model = {}  # ToolchainCollectionFirst
-        toolchain_collection_first_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains?resource_group_id=6a9a01f2cff54a7f966f803d92877123&limit=3"
+        toolchain_collection_first_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains?resource_group_id=6a9a01f2cff54a7f966f803d92877123&limit=3'
         )
 
         toolchain_collection_previous_model = {}  # ToolchainCollectionPrevious
-        toolchain_collection_previous_model["start"] = (
-            "eyJ0b29sY2hhaW5fZ3VpZCI6IjA4NDFlYTMxLTEzMDMtNDJiZC1hYmMyLTQzMjYzZDg0YmU0OSJ9"
+        toolchain_collection_previous_model['start'] = (
+            'eyJ0b29sY2hhaW5fZ3VpZCI6IjA4NDFlYTMxLTEzMDMtNDJiZC1hYmMyLTQzMjYzZDg0YmU0OSJ9'
         )
-        toolchain_collection_previous_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains?resource_group_id=6a9a01f2cff54a7f966f803d92877123&limit=3&start=eyJ0b29sY2hhaW5fZ3VpZCI6IjA4NDFlYTMxLTEzMDMtNDJiZC1hYmMyLTQzMjYzZDg0YmU0OSJ9"
+        toolchain_collection_previous_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains?resource_group_id=6a9a01f2cff54a7f966f803d92877123&limit=3&start=eyJ0b29sY2hhaW5fZ3VpZCI6IjA4NDFlYTMxLTEzMDMtNDJiZC1hYmMyLTQzMjYzZDg0YmU0OSJ9'
         )
 
         toolchain_collection_next_model = {}  # ToolchainCollectionNext
-        toolchain_collection_next_model["start"] = (
-            "eyJ0b29sY2hhaW5fZ3VpZCI6ImVhZGVmNGYzLThlMzktNDY2OS04NmY0LWU1NTA1MWExMjMzOCJ9"
+        toolchain_collection_next_model['start'] = (
+            'eyJ0b29sY2hhaW5fZ3VpZCI6ImVhZGVmNGYzLThlMzktNDY2OS04NmY0LWU1NTA1MWExMjMzOCJ9'
         )
-        toolchain_collection_next_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains?resource_group_id=6a9a01f2cff54a7f966f803d92877123&limit=3&start=eyJ0b29sY2hhaW5fZ3VpZCI6ImVhZGVmNGYzLThlMzktNDY2OS04NmY0LWU1NTA1MWExMjMzOCJ9"
+        toolchain_collection_next_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains?resource_group_id=6a9a01f2cff54a7f966f803d92877123&limit=3&start=eyJ0b29sY2hhaW5fZ3VpZCI6ImVhZGVmNGYzLThlMzktNDY2OS04NmY0LWU1NTA1MWExMjMzOCJ9'
         )
 
         toolchain_collection_last_model = {}  # ToolchainCollectionLast
-        toolchain_collection_last_model["start"] = (
-            "eyJ0b29sY2hhaW5fZ3VpZCI6ImYxNTI3ZjkyLTQyOTAtNGUzZi1iMmIzLTc3ODg5YTE0NDkzOCJ9"
+        toolchain_collection_last_model['start'] = (
+            'eyJ0b29sY2hhaW5fZ3VpZCI6ImYxNTI3ZjkyLTQyOTAtNGUzZi1iMmIzLTc3ODg5YTE0NDkzOCJ9'
         )
-        toolchain_collection_last_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains?resource_group_id=6a9a01f2cff54a7f966f803d92877123&limit=3&start=eyJ0b29sY2hhaW5fZ3VpZCI6ImYxNTI3ZjkyLTQyOTAtNGUzZi1iMmIzLTc3ODg5YTE0NDkzOCJ9"
+        toolchain_collection_last_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains?resource_group_id=6a9a01f2cff54a7f966f803d92877123&limit=3&start=eyJ0b29sY2hhaW5fZ3VpZCI6ImYxNTI3ZjkyLTQyOTAtNGUzZi1iMmIzLTc3ODg5YTE0NDkzOCJ9'
         )
 
         toolchain_model_model = {}  # ToolchainModel
-        toolchain_model_model["id"] = "62935028-0202-48fe-b877-7e99c817b856"
-        toolchain_model_model["name"] = "TestToolchainV2-2"
-        toolchain_model_model["description"] = "A second sample toolchain"
-        toolchain_model_model["account_id"] = "f2337426699b4041bc50f1d45042f777"
-        toolchain_model_model["location"] = "us-south"
-        toolchain_model_model["resource_group_id"] = "6a9a01f2cff54a7f966f803d92877123"
-        toolchain_model_model["crn"] = (
-            "crn:v1:staging:public:toolchain:us-south:a/f2337426699b4041bc50f1d45042f777:62935028-0202-48fe-b877-7e99c817b856::"
+        toolchain_model_model['id'] = '62935028-0202-48fe-b877-7e99c817b856'
+        toolchain_model_model['name'] = 'TestToolchainV2-2'
+        toolchain_model_model['description'] = 'A second sample toolchain'
+        toolchain_model_model['account_id'] = 'f2337426699b4041bc50f1d45042f777'
+        toolchain_model_model['location'] = 'us-south'
+        toolchain_model_model['resource_group_id'] = '6a9a01f2cff54a7f966f803d92877123'
+        toolchain_model_model['crn'] = (
+            'crn:v1:staging:public:toolchain:us-south:a/f2337426699b4041bc50f1d45042f777:62935028-0202-48fe-b877-7e99c817b856::'
         )
-        toolchain_model_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/62935028-0202-48fe-b877-7e99c817b856"
+        toolchain_model_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/62935028-0202-48fe-b877-7e99c817b856'
         )
-        toolchain_model_model["ui_href"] = "testString"
-        toolchain_model_model["created_at"] = "2021-05-05T17:07:09.354000Z"
-        toolchain_model_model["updated_at"] = "2022-01-01T13:13:07.968000Z"
-        toolchain_model_model["created_by"] = "IBMid-123456AB7C"
+        toolchain_model_model['ui_href'] = 'testString'
+        toolchain_model_model['created_at'] = '2021-05-05T17:07:09.354000Z'
+        toolchain_model_model['updated_at'] = '2022-01-01T13:13:07.968000Z'
+        toolchain_model_model['created_by'] = 'IBMid-123456AB7C'
 
         # Construct a json representation of a ToolchainCollection model
         toolchain_collection_model_json = {}
-        toolchain_collection_model_json["total_count"] = 38
-        toolchain_collection_model_json["limit"] = 38
-        toolchain_collection_model_json["first"] = toolchain_collection_first_model
-        toolchain_collection_model_json["previous"] = toolchain_collection_previous_model
-        toolchain_collection_model_json["next"] = toolchain_collection_next_model
-        toolchain_collection_model_json["last"] = toolchain_collection_last_model
-        toolchain_collection_model_json["toolchains"] = [toolchain_model_model]
+        toolchain_collection_model_json['total_count'] = 38
+        toolchain_collection_model_json['limit'] = 38
+        toolchain_collection_model_json['first'] = toolchain_collection_first_model
+        toolchain_collection_model_json['previous'] = toolchain_collection_previous_model
+        toolchain_collection_model_json['next'] = toolchain_collection_next_model
+        toolchain_collection_model_json['last'] = toolchain_collection_last_model
+        toolchain_collection_model_json['toolchains'] = [toolchain_model_model]
 
         # Construct a model instance of ToolchainCollection by calling from_dict on the json representation
         toolchain_collection_model = ToolchainCollection.from_dict(toolchain_collection_model_json)
@@ -1624,7 +1629,7 @@ class TestModel_ToolchainCollectionFirst:
 
         # Construct a json representation of a ToolchainCollectionFirst model
         toolchain_collection_first_model_json = {}
-        toolchain_collection_first_model_json["href"] = "testString"
+        toolchain_collection_first_model_json['href'] = 'testString'
 
         # Construct a model instance of ToolchainCollectionFirst by calling from_dict on the json representation
         toolchain_collection_first_model = ToolchainCollectionFirst.from_dict(toolchain_collection_first_model_json)
@@ -1656,8 +1661,8 @@ class TestModel_ToolchainCollectionLast:
 
         # Construct a json representation of a ToolchainCollectionLast model
         toolchain_collection_last_model_json = {}
-        toolchain_collection_last_model_json["start"] = "testString"
-        toolchain_collection_last_model_json["href"] = "testString"
+        toolchain_collection_last_model_json['start'] = 'testString'
+        toolchain_collection_last_model_json['href'] = 'testString'
 
         # Construct a model instance of ToolchainCollectionLast by calling from_dict on the json representation
         toolchain_collection_last_model = ToolchainCollectionLast.from_dict(toolchain_collection_last_model_json)
@@ -1689,8 +1694,8 @@ class TestModel_ToolchainCollectionNext:
 
         # Construct a json representation of a ToolchainCollectionNext model
         toolchain_collection_next_model_json = {}
-        toolchain_collection_next_model_json["start"] = "testString"
-        toolchain_collection_next_model_json["href"] = "testString"
+        toolchain_collection_next_model_json['start'] = 'testString'
+        toolchain_collection_next_model_json['href'] = 'testString'
 
         # Construct a model instance of ToolchainCollectionNext by calling from_dict on the json representation
         toolchain_collection_next_model = ToolchainCollectionNext.from_dict(toolchain_collection_next_model_json)
@@ -1722,8 +1727,8 @@ class TestModel_ToolchainCollectionPrevious:
 
         # Construct a json representation of a ToolchainCollectionPrevious model
         toolchain_collection_previous_model_json = {}
-        toolchain_collection_previous_model_json["start"] = "testString"
-        toolchain_collection_previous_model_json["href"] = "testString"
+        toolchain_collection_previous_model_json['start'] = 'testString'
+        toolchain_collection_previous_model_json['href'] = 'testString'
 
         # Construct a model instance of ToolchainCollectionPrevious by calling from_dict on the json representation
         toolchain_collection_previous_model = ToolchainCollectionPrevious.from_dict(
@@ -1757,7 +1762,7 @@ class TestModel_ToolchainEventPost:
 
         # Construct a json representation of a ToolchainEventPost model
         toolchain_event_post_model_json = {}
-        toolchain_event_post_model_json["id"] = "testString"
+        toolchain_event_post_model_json['id'] = 'testString'
 
         # Construct a model instance of ToolchainEventPost by calling from_dict on the json representation
         toolchain_event_post_model = ToolchainEventPost.from_dict(toolchain_event_post_model_json)
@@ -1788,14 +1793,23 @@ class TestModel_ToolchainEventPrototypeData:
         # Construct dict forms of any model objects needed in order to build this model.
 
         toolchain_event_prototype_data_application_json_model = {}  # ToolchainEventPrototypeDataApplicationJson
-        toolchain_event_prototype_data_application_json_model["content"] = {"anyKey": "anyValue"}
+        toolchain_event_prototype_data_application_json_model['content'] = {
+            'customKey1': 'myCustomData',
+            'customKey2': 123,
+            'customKey3': {'nestedKey': 'moreData'},
+        }
+
+        toolchain_event_prototype_data_text_plain_model = {}  # ToolchainEventPrototypeDataTextPlain
+        toolchain_event_prototype_data_text_plain_model['content'] = (
+            'This event is dispatched because the pipeline failed'
+        )
 
         # Construct a json representation of a ToolchainEventPrototypeData model
         toolchain_event_prototype_data_model_json = {}
-        toolchain_event_prototype_data_model_json["application_json"] = (
+        toolchain_event_prototype_data_model_json['application_json'] = (
             toolchain_event_prototype_data_application_json_model
         )
-        toolchain_event_prototype_data_model_json["text_plain"] = "This event is dispatched because the pipeline failed"
+        toolchain_event_prototype_data_model_json['text_plain'] = toolchain_event_prototype_data_text_plain_model
 
         # Construct a model instance of ToolchainEventPrototypeData by calling from_dict on the json representation
         toolchain_event_prototype_data_model = ToolchainEventPrototypeData.from_dict(
@@ -1829,7 +1843,11 @@ class TestModel_ToolchainEventPrototypeDataApplicationJson:
 
         # Construct a json representation of a ToolchainEventPrototypeDataApplicationJson model
         toolchain_event_prototype_data_application_json_model_json = {}
-        toolchain_event_prototype_data_application_json_model_json["content"] = {"anyKey": "anyValue"}
+        toolchain_event_prototype_data_application_json_model_json['content'] = {
+            'customKey1': 'myCustomData',
+            'customKey2': 123,
+            'customKey3': {'nestedKey': 'moreData'},
+        }
 
         # Construct a model instance of ToolchainEventPrototypeDataApplicationJson by calling from_dict on the json representation
         toolchain_event_prototype_data_application_json_model = ToolchainEventPrototypeDataApplicationJson.from_dict(
@@ -1863,6 +1881,49 @@ class TestModel_ToolchainEventPrototypeDataApplicationJson:
         )
 
 
+class TestModel_ToolchainEventPrototypeDataTextPlain:
+    """
+    Test Class for ToolchainEventPrototypeDataTextPlain
+    """
+
+    def test_toolchain_event_prototype_data_text_plain_serialization(self):
+        """
+        Test serialization/deserialization for ToolchainEventPrototypeDataTextPlain
+        """
+
+        # Construct a json representation of a ToolchainEventPrototypeDataTextPlain model
+        toolchain_event_prototype_data_text_plain_model_json = {}
+        toolchain_event_prototype_data_text_plain_model_json['content'] = (
+            'This event is dispatched because the pipeline failed'
+        )
+
+        # Construct a model instance of ToolchainEventPrototypeDataTextPlain by calling from_dict on the json representation
+        toolchain_event_prototype_data_text_plain_model = ToolchainEventPrototypeDataTextPlain.from_dict(
+            toolchain_event_prototype_data_text_plain_model_json
+        )
+        assert toolchain_event_prototype_data_text_plain_model != False
+
+        # Construct a model instance of ToolchainEventPrototypeDataTextPlain by calling from_dict on the json representation
+        toolchain_event_prototype_data_text_plain_model_dict = ToolchainEventPrototypeDataTextPlain.from_dict(
+            toolchain_event_prototype_data_text_plain_model_json
+        ).__dict__
+        toolchain_event_prototype_data_text_plain_model2 = ToolchainEventPrototypeDataTextPlain(
+            **toolchain_event_prototype_data_text_plain_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert toolchain_event_prototype_data_text_plain_model == toolchain_event_prototype_data_text_plain_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        toolchain_event_prototype_data_text_plain_model_json2 = (
+            toolchain_event_prototype_data_text_plain_model.to_dict()
+        )
+        assert (
+            toolchain_event_prototype_data_text_plain_model_json2
+            == toolchain_event_prototype_data_text_plain_model_json
+        )
+
+
 class TestModel_ToolchainModel:
     """
     Test Class for ToolchainModel
@@ -1875,18 +1936,18 @@ class TestModel_ToolchainModel:
 
         # Construct a json representation of a ToolchainModel model
         toolchain_model_model_json = {}
-        toolchain_model_model_json["id"] = "testString"
-        toolchain_model_model_json["name"] = "TestToolchainV2"
-        toolchain_model_model_json["description"] = "A sample toolchain to test the API"
-        toolchain_model_model_json["account_id"] = "testString"
-        toolchain_model_model_json["location"] = "testString"
-        toolchain_model_model_json["resource_group_id"] = "6a9a01f2cff54a7f966f803d92877123"
-        toolchain_model_model_json["crn"] = "testString"
-        toolchain_model_model_json["href"] = "testString"
-        toolchain_model_model_json["ui_href"] = "testString"
-        toolchain_model_model_json["created_at"] = "2019-01-01T12:00:00Z"
-        toolchain_model_model_json["updated_at"] = "2019-01-01T12:00:00Z"
-        toolchain_model_model_json["created_by"] = "testString"
+        toolchain_model_model_json['id'] = 'testString'
+        toolchain_model_model_json['name'] = 'TestToolchainV2'
+        toolchain_model_model_json['description'] = 'A sample toolchain to test the API'
+        toolchain_model_model_json['account_id'] = 'testString'
+        toolchain_model_model_json['location'] = 'testString'
+        toolchain_model_model_json['resource_group_id'] = '6a9a01f2cff54a7f966f803d92877123'
+        toolchain_model_model_json['crn'] = 'testString'
+        toolchain_model_model_json['href'] = 'testString'
+        toolchain_model_model_json['ui_href'] = 'testString'
+        toolchain_model_model_json['created_at'] = '2019-01-01T12:00:00Z'
+        toolchain_model_model_json['updated_at'] = '2019-01-01T12:00:00Z'
+        toolchain_model_model_json['created_by'] = 'testString'
 
         # Construct a model instance of ToolchainModel by calling from_dict on the json representation
         toolchain_model_model = ToolchainModel.from_dict(toolchain_model_model_json)
@@ -1916,18 +1977,18 @@ class TestModel_ToolchainPatch:
 
         # Construct a json representation of a ToolchainPatch model
         toolchain_patch_model_json = {}
-        toolchain_patch_model_json["id"] = "testString"
-        toolchain_patch_model_json["name"] = "TestToolchainV2"
-        toolchain_patch_model_json["description"] = "A sample toolchain to test the API"
-        toolchain_patch_model_json["account_id"] = "testString"
-        toolchain_patch_model_json["location"] = "testString"
-        toolchain_patch_model_json["resource_group_id"] = "6a9a01f2cff54a7f966f803d92877123"
-        toolchain_patch_model_json["crn"] = "testString"
-        toolchain_patch_model_json["href"] = "testString"
-        toolchain_patch_model_json["ui_href"] = "testString"
-        toolchain_patch_model_json["created_at"] = "2019-01-01T12:00:00Z"
-        toolchain_patch_model_json["updated_at"] = "2019-01-01T12:00:00Z"
-        toolchain_patch_model_json["created_by"] = "testString"
+        toolchain_patch_model_json['id'] = 'testString'
+        toolchain_patch_model_json['name'] = 'TestToolchainV2'
+        toolchain_patch_model_json['description'] = 'A sample toolchain to test the API'
+        toolchain_patch_model_json['account_id'] = 'testString'
+        toolchain_patch_model_json['location'] = 'testString'
+        toolchain_patch_model_json['resource_group_id'] = '6a9a01f2cff54a7f966f803d92877123'
+        toolchain_patch_model_json['crn'] = 'testString'
+        toolchain_patch_model_json['href'] = 'testString'
+        toolchain_patch_model_json['ui_href'] = 'testString'
+        toolchain_patch_model_json['created_at'] = '2019-01-01T12:00:00Z'
+        toolchain_patch_model_json['updated_at'] = '2019-01-01T12:00:00Z'
+        toolchain_patch_model_json['created_by'] = 'testString'
 
         # Construct a model instance of ToolchainPatch by calling from_dict on the json representation
         toolchain_patch_model = ToolchainPatch.from_dict(toolchain_patch_model_json)
@@ -1957,18 +2018,18 @@ class TestModel_ToolchainPost:
 
         # Construct a json representation of a ToolchainPost model
         toolchain_post_model_json = {}
-        toolchain_post_model_json["id"] = "testString"
-        toolchain_post_model_json["name"] = "TestToolchainV2"
-        toolchain_post_model_json["description"] = "A sample toolchain to test the API"
-        toolchain_post_model_json["account_id"] = "testString"
-        toolchain_post_model_json["location"] = "testString"
-        toolchain_post_model_json["resource_group_id"] = "6a9a01f2cff54a7f966f803d92877123"
-        toolchain_post_model_json["crn"] = "testString"
-        toolchain_post_model_json["href"] = "testString"
-        toolchain_post_model_json["ui_href"] = "testString"
-        toolchain_post_model_json["created_at"] = "2019-01-01T12:00:00Z"
-        toolchain_post_model_json["updated_at"] = "2019-01-01T12:00:00Z"
-        toolchain_post_model_json["created_by"] = "testString"
+        toolchain_post_model_json['id'] = 'testString'
+        toolchain_post_model_json['name'] = 'TestToolchainV2'
+        toolchain_post_model_json['description'] = 'A sample toolchain to test the API'
+        toolchain_post_model_json['account_id'] = 'testString'
+        toolchain_post_model_json['location'] = 'testString'
+        toolchain_post_model_json['resource_group_id'] = '6a9a01f2cff54a7f966f803d92877123'
+        toolchain_post_model_json['crn'] = 'testString'
+        toolchain_post_model_json['href'] = 'testString'
+        toolchain_post_model_json['ui_href'] = 'testString'
+        toolchain_post_model_json['created_at'] = '2019-01-01T12:00:00Z'
+        toolchain_post_model_json['updated_at'] = '2019-01-01T12:00:00Z'
+        toolchain_post_model_json['created_by'] = 'testString'
 
         # Construct a model instance of ToolchainPost by calling from_dict on the json representation
         toolchain_post_model = ToolchainPost.from_dict(toolchain_post_model_json)
@@ -1998,8 +2059,8 @@ class TestModel_ToolchainPrototypePatch:
 
         # Construct a json representation of a ToolchainPrototypePatch model
         toolchain_prototype_patch_model_json = {}
-        toolchain_prototype_patch_model_json["name"] = "newToolchainName"
-        toolchain_prototype_patch_model_json["description"] = "New toolchain description"
+        toolchain_prototype_patch_model_json['name'] = 'newToolchainName'
+        toolchain_prototype_patch_model_json['description'] = 'New toolchain description'
 
         # Construct a model instance of ToolchainPrototypePatch by calling from_dict on the json representation
         toolchain_prototype_patch_model = ToolchainPrototypePatch.from_dict(toolchain_prototype_patch_model_json)
@@ -2032,23 +2093,23 @@ class TestModel_ToolchainTool:
         # Construct dict forms of any model objects needed in order to build this model.
 
         tool_model_referent_model = {}  # ToolModelReferent
-        tool_model_referent_model["ui_href"] = "https://my-team.slack.com/messages/my-channel"
-        tool_model_referent_model["api_href"] = "testString"
+        tool_model_referent_model['ui_href'] = 'https://my-team.slack.com/messages/my-channel'
+        tool_model_referent_model['api_href'] = 'testString'
 
         # Construct a json representation of a ToolchainTool model
         toolchain_tool_model_json = {}
-        toolchain_tool_model_json["id"] = "testString"
-        toolchain_tool_model_json["resource_group_id"] = "testString"
-        toolchain_tool_model_json["crn"] = "testString"
-        toolchain_tool_model_json["tool_type_id"] = "testString"
-        toolchain_tool_model_json["toolchain_id"] = "testString"
-        toolchain_tool_model_json["toolchain_crn"] = "testString"
-        toolchain_tool_model_json["href"] = "testString"
-        toolchain_tool_model_json["referent"] = tool_model_referent_model
-        toolchain_tool_model_json["name"] = "MyTool"
-        toolchain_tool_model_json["updated_at"] = "2019-01-01T12:00:00Z"
-        toolchain_tool_model_json["parameters"] = {"anyKey": "anyValue"}
-        toolchain_tool_model_json["state"] = "configured"
+        toolchain_tool_model_json['id'] = 'testString'
+        toolchain_tool_model_json['resource_group_id'] = 'testString'
+        toolchain_tool_model_json['crn'] = 'testString'
+        toolchain_tool_model_json['tool_type_id'] = 'testString'
+        toolchain_tool_model_json['toolchain_id'] = 'testString'
+        toolchain_tool_model_json['toolchain_crn'] = 'testString'
+        toolchain_tool_model_json['href'] = 'testString'
+        toolchain_tool_model_json['referent'] = tool_model_referent_model
+        toolchain_tool_model_json['name'] = 'MyTool'
+        toolchain_tool_model_json['updated_at'] = '2019-01-01T12:00:00Z'
+        toolchain_tool_model_json['parameters'] = {'anyKey': 'anyValue'}
+        toolchain_tool_model_json['state'] = 'configured'
 
         # Construct a model instance of ToolchainTool by calling from_dict on the json representation
         toolchain_tool_model = ToolchainTool.from_dict(toolchain_tool_model_json)
@@ -2079,67 +2140,72 @@ class TestModel_ToolchainToolCollection:
         # Construct dict forms of any model objects needed in order to build this model.
 
         toolchain_tool_collection_first_model = {}  # ToolchainToolCollectionFirst
-        toolchain_tool_collection_first_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools?limit=3"
+        toolchain_tool_collection_first_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools?limit=3'
         )
 
         toolchain_tool_collection_previous_model = {}  # ToolchainToolCollectionPrevious
-        toolchain_tool_collection_previous_model["start"] = (
-            "eyJpbnN0YW5jZV9pZCI6IjEzODgxYTZkLWI1ZDktNDQwNi05MzFmLWM4NTc1NDc0MmQ1NSJ9"
+        toolchain_tool_collection_previous_model['start'] = (
+            'eyJpbnN0YW5jZV9pZCI6IjEzODgxYTZkLWI1ZDktNDQwNi05MzFmLWM4NTc1NDc0MmQ1NSJ9'
         )
-        toolchain_tool_collection_previous_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools?limit=3&start=eyJpbnN0YW5jZV9pZCI6IjEzODgxYTZkLWI1ZDktNDQwNi05MzFmLWM4NTc1NDc0MmQ1NSJ9"
+        toolchain_tool_collection_previous_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools?limit=3&start=eyJpbnN0YW5jZV9pZCI6IjEzODgxYTZkLWI1ZDktNDQwNi05MzFmLWM4NTc1NDc0MmQ1NSJ9'
         )
 
         toolchain_tool_collection_next_model = {}  # ToolchainToolCollectionNext
-        toolchain_tool_collection_next_model["start"] = (
-            "eyJpbnN0YW5jZV9pZCI6IjlkZDBjNDc3LWYxNzMtNGMzZi1hN2NmLWQyNzAyNmFjZTM3OSJ9"
+        toolchain_tool_collection_next_model['start'] = (
+            'eyJpbnN0YW5jZV9pZCI6IjlkZDBjNDc3LWYxNzMtNGMzZi1hN2NmLWQyNzAyNmFjZTM3OSJ9'
         )
-        toolchain_tool_collection_next_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools?limit=3&start=eyJpbnN0YW5jZV9pZCI6IjlkZDBjNDc3LWYxNzMtNGMzZi1hN2NmLWQyNzAyNmFjZTM3OSJ9"
+        toolchain_tool_collection_next_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools?limit=3&start=eyJpbnN0YW5jZV9pZCI6IjlkZDBjNDc3LWYxNzMtNGMzZi1hN2NmLWQyNzAyNmFjZTM3OSJ9'
         )
 
         toolchain_tool_collection_last_model = {}  # ToolchainToolCollectionLast
-        toolchain_tool_collection_last_model["start"] = (
-            "eyJpbnN0YW5jZV9pZCI6ImQzYzkxMDYwLTcwOWMtNGZmZi1hODUwLTllZDFkZWMwMGYxYiJ9"
+        toolchain_tool_collection_last_model['start'] = (
+            'eyJpbnN0YW5jZV9pZCI6ImQzYzkxMDYwLTcwOWMtNGZmZi1hODUwLTllZDFkZWMwMGYxYiJ9'
         )
-        toolchain_tool_collection_last_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools?limit=3&start=eyJpbnN0YW5jZV9pZCI6ImQzYzkxMDYwLTcwOWMtNGZmZi1hODUwLTllZDFkZWMwMGYxYiJ9"
+        toolchain_tool_collection_last_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools?limit=3&start=eyJpbnN0YW5jZV9pZCI6ImQzYzkxMDYwLTcwOWMtNGZmZi1hODUwLTllZDFkZWMwMGYxYiJ9'
         )
 
         tool_model_referent_model = {}  # ToolModelReferent
-        tool_model_referent_model["ui_href"] = "https://team-one.slack.com/messages/channel-one"
-        tool_model_referent_model["api_href"] = "testString"
+        tool_model_referent_model['ui_href'] = 'https://team-one.slack.com/messages/channel-one'
+        tool_model_referent_model['api_href'] = 'testString'
 
         tool_model_model = {}  # ToolModel
-        tool_model_model["id"] = "2983b160-fc37-4c45-8a8f-e616ad7e470b"
-        tool_model_model["resource_group_id"] = "6a9a01f2cff54a7f966f803d92877123"
-        tool_model_model["crn"] = (
-            "crn:v1:staging:public:toolchain:us-south:a/f2337426699b4041bc50f1d45042f777:d02d29f1-e7bb-4977-8a6f-26d7b7bb893e:tool:2983b160-fc37-4c45-8a8f-e616ad7e470b"
+        tool_model_model['id'] = '2983b160-fc37-4c45-8a8f-e616ad7e470b'
+        tool_model_model['resource_group_id'] = '6a9a01f2cff54a7f966f803d92877123'
+        tool_model_model['crn'] = (
+            'crn:v1:staging:public:toolchain:us-south:a/f2337426699b4041bc50f1d45042f777:d02d29f1-e7bb-4977-8a6f-26d7b7bb893e:tool:2983b160-fc37-4c45-8a8f-e616ad7e470b'
         )
-        tool_model_model["tool_type_id"] = "slack"
-        tool_model_model["toolchain_id"] = "d02d29f1-e7bb-4977-8a6f-26d7b7bb893e"
-        tool_model_model["toolchain_crn"] = (
-            "crn:v1:staging:public:toolchain:us-south:a/f2337426699b4041bc50f1d45042f777:d02d29f1-e7bb-4977-8a6f-26d7b7bb893e::"
+        tool_model_model['tool_type_id'] = 'slack'
+        tool_model_model['toolchain_id'] = 'd02d29f1-e7bb-4977-8a6f-26d7b7bb893e'
+        tool_model_model['toolchain_crn'] = (
+            'crn:v1:staging:public:toolchain:us-south:a/f2337426699b4041bc50f1d45042f777:d02d29f1-e7bb-4977-8a6f-26d7b7bb893e::'
         )
-        tool_model_model["href"] = (
-            "https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools/2983b160-fc37-4c45-8a8f-e616ad7e470b"
+        tool_model_model['href'] = (
+            'https://api.us-south.devops.cloud.ibm.com/toolchain/v2/toolchains/d02d29f1-e7bb-4977-8a6f-26d7b7bb893e/tools/2983b160-fc37-4c45-8a8f-e616ad7e470b'
         )
-        tool_model_model["referent"] = tool_model_referent_model
-        tool_model_model["name"] = "MyTool-1"
-        tool_model_model["updated_at"] = "2022-01-01T13:13:07.968000Z"
-        tool_model_model["parameters"] = {"anyKey": "anyValue"}
-        tool_model_model["state"] = "configured"
+        tool_model_model['referent'] = tool_model_referent_model
+        tool_model_model['name'] = 'MyTool-1'
+        tool_model_model['updated_at'] = '2022-01-01T13:13:07.968000Z'
+        tool_model_model['parameters'] = {
+            'label': '#channel-one',
+            'channel_name': 'channel-one',
+            'team_url': 'team-one',
+            'apikey': 'hash:SHA3-512:5bad9f13ac3580162ddb2980909fe3375a64e61b5c3d78d819cc02e84f98810dc5f8b848e07babedeaaabf78cfcbb71fe6098ea294b702a9deff904836322bd2',
+        }
+        tool_model_model['state'] = 'configured'
 
         # Construct a json representation of a ToolchainToolCollection model
         toolchain_tool_collection_model_json = {}
-        toolchain_tool_collection_model_json["limit"] = 38
-        toolchain_tool_collection_model_json["total_count"] = 38
-        toolchain_tool_collection_model_json["first"] = toolchain_tool_collection_first_model
-        toolchain_tool_collection_model_json["previous"] = toolchain_tool_collection_previous_model
-        toolchain_tool_collection_model_json["next"] = toolchain_tool_collection_next_model
-        toolchain_tool_collection_model_json["last"] = toolchain_tool_collection_last_model
-        toolchain_tool_collection_model_json["tools"] = [tool_model_model]
+        toolchain_tool_collection_model_json['limit'] = 38
+        toolchain_tool_collection_model_json['total_count'] = 38
+        toolchain_tool_collection_model_json['first'] = toolchain_tool_collection_first_model
+        toolchain_tool_collection_model_json['previous'] = toolchain_tool_collection_previous_model
+        toolchain_tool_collection_model_json['next'] = toolchain_tool_collection_next_model
+        toolchain_tool_collection_model_json['last'] = toolchain_tool_collection_last_model
+        toolchain_tool_collection_model_json['tools'] = [tool_model_model]
 
         # Construct a model instance of ToolchainToolCollection by calling from_dict on the json representation
         toolchain_tool_collection_model = ToolchainToolCollection.from_dict(toolchain_tool_collection_model_json)
@@ -2171,7 +2237,7 @@ class TestModel_ToolchainToolCollectionFirst:
 
         # Construct a json representation of a ToolchainToolCollectionFirst model
         toolchain_tool_collection_first_model_json = {}
-        toolchain_tool_collection_first_model_json["href"] = "testString"
+        toolchain_tool_collection_first_model_json['href'] = 'testString'
 
         # Construct a model instance of ToolchainToolCollectionFirst by calling from_dict on the json representation
         toolchain_tool_collection_first_model = ToolchainToolCollectionFirst.from_dict(
@@ -2207,8 +2273,8 @@ class TestModel_ToolchainToolCollectionLast:
 
         # Construct a json representation of a ToolchainToolCollectionLast model
         toolchain_tool_collection_last_model_json = {}
-        toolchain_tool_collection_last_model_json["start"] = "testString"
-        toolchain_tool_collection_last_model_json["href"] = "testString"
+        toolchain_tool_collection_last_model_json['start'] = 'testString'
+        toolchain_tool_collection_last_model_json['href'] = 'testString'
 
         # Construct a model instance of ToolchainToolCollectionLast by calling from_dict on the json representation
         toolchain_tool_collection_last_model = ToolchainToolCollectionLast.from_dict(
@@ -2242,8 +2308,8 @@ class TestModel_ToolchainToolCollectionNext:
 
         # Construct a json representation of a ToolchainToolCollectionNext model
         toolchain_tool_collection_next_model_json = {}
-        toolchain_tool_collection_next_model_json["start"] = "testString"
-        toolchain_tool_collection_next_model_json["href"] = "testString"
+        toolchain_tool_collection_next_model_json['start'] = 'testString'
+        toolchain_tool_collection_next_model_json['href'] = 'testString'
 
         # Construct a model instance of ToolchainToolCollectionNext by calling from_dict on the json representation
         toolchain_tool_collection_next_model = ToolchainToolCollectionNext.from_dict(
@@ -2277,8 +2343,8 @@ class TestModel_ToolchainToolCollectionPrevious:
 
         # Construct a json representation of a ToolchainToolCollectionPrevious model
         toolchain_tool_collection_previous_model_json = {}
-        toolchain_tool_collection_previous_model_json["start"] = "testString"
-        toolchain_tool_collection_previous_model_json["href"] = "testString"
+        toolchain_tool_collection_previous_model_json['start'] = 'testString'
+        toolchain_tool_collection_previous_model_json['href'] = 'testString'
 
         # Construct a model instance of ToolchainToolCollectionPrevious by calling from_dict on the json representation
         toolchain_tool_collection_previous_model = ToolchainToolCollectionPrevious.from_dict(
@@ -2315,23 +2381,23 @@ class TestModel_ToolchainToolPatch:
         # Construct dict forms of any model objects needed in order to build this model.
 
         tool_model_referent_model = {}  # ToolModelReferent
-        tool_model_referent_model["ui_href"] = "https://my-team.slack.com/messages/my-channel"
-        tool_model_referent_model["api_href"] = "testString"
+        tool_model_referent_model['ui_href'] = 'https://my-team.slack.com/messages/my-channel'
+        tool_model_referent_model['api_href'] = 'testString'
 
         # Construct a json representation of a ToolchainToolPatch model
         toolchain_tool_patch_model_json = {}
-        toolchain_tool_patch_model_json["id"] = "testString"
-        toolchain_tool_patch_model_json["resource_group_id"] = "testString"
-        toolchain_tool_patch_model_json["crn"] = "testString"
-        toolchain_tool_patch_model_json["tool_type_id"] = "testString"
-        toolchain_tool_patch_model_json["toolchain_id"] = "testString"
-        toolchain_tool_patch_model_json["toolchain_crn"] = "testString"
-        toolchain_tool_patch_model_json["href"] = "testString"
-        toolchain_tool_patch_model_json["referent"] = tool_model_referent_model
-        toolchain_tool_patch_model_json["name"] = "MyTool"
-        toolchain_tool_patch_model_json["updated_at"] = "2019-01-01T12:00:00Z"
-        toolchain_tool_patch_model_json["parameters"] = {"anyKey": "anyValue"}
-        toolchain_tool_patch_model_json["state"] = "configured"
+        toolchain_tool_patch_model_json['id'] = 'testString'
+        toolchain_tool_patch_model_json['resource_group_id'] = 'testString'
+        toolchain_tool_patch_model_json['crn'] = 'testString'
+        toolchain_tool_patch_model_json['tool_type_id'] = 'testString'
+        toolchain_tool_patch_model_json['toolchain_id'] = 'testString'
+        toolchain_tool_patch_model_json['toolchain_crn'] = 'testString'
+        toolchain_tool_patch_model_json['href'] = 'testString'
+        toolchain_tool_patch_model_json['referent'] = tool_model_referent_model
+        toolchain_tool_patch_model_json['name'] = 'MyTool'
+        toolchain_tool_patch_model_json['updated_at'] = '2019-01-01T12:00:00Z'
+        toolchain_tool_patch_model_json['parameters'] = {'anyKey': 'anyValue'}
+        toolchain_tool_patch_model_json['state'] = 'configured'
 
         # Construct a model instance of ToolchainToolPatch by calling from_dict on the json representation
         toolchain_tool_patch_model = ToolchainToolPatch.from_dict(toolchain_tool_patch_model_json)
@@ -2362,23 +2428,23 @@ class TestModel_ToolchainToolPost:
         # Construct dict forms of any model objects needed in order to build this model.
 
         tool_model_referent_model = {}  # ToolModelReferent
-        tool_model_referent_model["ui_href"] = "https://my-team.slack.com/messages/my-channel"
-        tool_model_referent_model["api_href"] = "testString"
+        tool_model_referent_model['ui_href'] = 'https://my-team.slack.com/messages/my-channel'
+        tool_model_referent_model['api_href'] = 'testString'
 
         # Construct a json representation of a ToolchainToolPost model
         toolchain_tool_post_model_json = {}
-        toolchain_tool_post_model_json["id"] = "testString"
-        toolchain_tool_post_model_json["resource_group_id"] = "testString"
-        toolchain_tool_post_model_json["crn"] = "testString"
-        toolchain_tool_post_model_json["tool_type_id"] = "testString"
-        toolchain_tool_post_model_json["toolchain_id"] = "testString"
-        toolchain_tool_post_model_json["toolchain_crn"] = "testString"
-        toolchain_tool_post_model_json["href"] = "testString"
-        toolchain_tool_post_model_json["referent"] = tool_model_referent_model
-        toolchain_tool_post_model_json["name"] = "MyTool"
-        toolchain_tool_post_model_json["updated_at"] = "2019-01-01T12:00:00Z"
-        toolchain_tool_post_model_json["parameters"] = {"anyKey": "anyValue"}
-        toolchain_tool_post_model_json["state"] = "configured"
+        toolchain_tool_post_model_json['id'] = 'testString'
+        toolchain_tool_post_model_json['resource_group_id'] = 'testString'
+        toolchain_tool_post_model_json['crn'] = 'testString'
+        toolchain_tool_post_model_json['tool_type_id'] = 'testString'
+        toolchain_tool_post_model_json['toolchain_id'] = 'testString'
+        toolchain_tool_post_model_json['toolchain_crn'] = 'testString'
+        toolchain_tool_post_model_json['href'] = 'testString'
+        toolchain_tool_post_model_json['referent'] = tool_model_referent_model
+        toolchain_tool_post_model_json['name'] = 'MyTool'
+        toolchain_tool_post_model_json['updated_at'] = '2019-01-01T12:00:00Z'
+        toolchain_tool_post_model_json['parameters'] = {'anyKey': 'anyValue'}
+        toolchain_tool_post_model_json['state'] = 'configured'
 
         # Construct a model instance of ToolchainToolPost by calling from_dict on the json representation
         toolchain_tool_post_model = ToolchainToolPost.from_dict(toolchain_tool_post_model_json)
@@ -2408,9 +2474,9 @@ class TestModel_ToolchainToolPrototypePatch:
 
         # Construct a json representation of a ToolchainToolPrototypePatch model
         toolchain_tool_prototype_patch_model_json = {}
-        toolchain_tool_prototype_patch_model_json["name"] = "MyTool"
-        toolchain_tool_prototype_patch_model_json["tool_type_id"] = "draservicebroker"
-        toolchain_tool_prototype_patch_model_json["parameters"] = {"anyKey": "anyValue"}
+        toolchain_tool_prototype_patch_model_json['name'] = 'MyTool'
+        toolchain_tool_prototype_patch_model_json['tool_type_id'] = 'draservicebroker'
+        toolchain_tool_prototype_patch_model_json['parameters'] = {'anyKey': 'anyValue'}
 
         # Construct a model instance of ToolchainToolPrototypePatch by calling from_dict on the json representation
         toolchain_tool_prototype_patch_model = ToolchainToolPrototypePatch.from_dict(


### PR DESCRIPTION
## PR summary
Updated SDK error formats. Also replaced the `text_plain` property with `ToolchainEventPrototypeDataTextPlain` in the `ToolchainEventPrototypeData`. This is a breaking change, and users will have to adjust accordingly.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Users can send text plain toolchain events by providing a string in the `ToolchainEventPrototypeData.text_plain` property

## What is the new behavior?  
Users can send text plain toolchain events by providing a string in the `ToolchainEventPrototypeData.ToolchainEventPrototypeDataTextPlain.content` property

## Does this PR introduce a breaking change?    
- [x] Yes
- [ ] No

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->