### PR TITLE
fix: drop support for python 3.9 as it is EOL

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     
     steps:
       - name: Checkout code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Run CI build
         run: make ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Install Node.js dependencies
         run: npm install

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Python client library to interact with the [IBM Cloud Continuous Delivery To
 ## Version
 
 - The current version of this SDK: 2.0.6
-- The current minimum Python version supported: 3.9
+- The current minimum Python version supported: 3.10
 
 ## Table of Contents
 
@@ -58,7 +58,7 @@ Service Name | Module Name | Imported Class Name
 
 - An [IBM Cloud][ibm-cloud-onboarding] account.
 - An IAM API key to allow the SDK to access your account. Create one [here](https://cloud.ibm.com/iam/apikeys).
-- Python 3.9 or above.
+- Python 3.10 or above.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,15 +6,15 @@ authors = [
 ]
 description = "Python client library to interact with the IBM Cloud Continuous Delivery Toolchain and Tekton Pipeline APIs"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",


### PR DESCRIPTION
## PR summary
Python v3.9 is EOL, see: https://devguide.python.org/versions/. Removing this version from our builds and supported version list.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No
